### PR TITLE
bootstrap: establish Crossdock public project

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,19 @@
+---
+name: Feature or improvement
+about: Propose bounded Crossdock product or implementation work
+title: ""
+labels: ""
+assignees: ""
+---
+
+## Problem
+
+## Desired outcome
+
+## Constraints / boundaries
+
+## Desktop / mobile implications
+
+## Security / privacy implications
+
+## Acceptance evidence

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What changes, and why? -->
+
+## Validation
+
+<!-- Tests/checks/manual validation. -->
+
+## UX / compatibility
+
+<!-- Desktop/mobile/provider implications, or N/A. -->
+
+## Security / privacy
+
+<!-- Data, permissions, authentication, storage, or browser-boundary implications, or N/A. -->
+
+## Issue
+
+<!-- Closes #... when applicable. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Crossdock Agent Guide
+
+Crossdock is a public implementation and contribution repository. It owns Crossdock application code, public technical documentation, tests, releases, and implementation-level schemas/adapters. Private Seedbed Product requirements and Company governance remain upstream authorities and must not be copied here as private content.
+
+## Working rules
+
+1. Read this file, the root README, and the relevant docs/source/tests before consequential changes.
+2. Keep provider-specific behavior behind explicit boundaries where practical; ChatGPT, Codex, and GitHub are initial integrations rather than Crossdock's domain model.
+3. Do not put private prompts, execution reports, credentials, tokens, customer data, or Seedbed-private task logs in this public repository.
+4. Fail closed when a target repository, branch, PR, browser control, or task-record destination is ambiguous.
+5. Preserve immutable task-record and remote-verification semantics when changing handoff behavior.
+6. Treat desktop and mobile as first-class experiences sharing one workflow model, not as separate products.
+7. Work through public issues/PRs for actionable design, documentation, implementation, and compatibility work.
+
+## Validation
+
+For the migrated Node handoff core, run:
+
+```text
+npm test
+npm run check
+```
+
+Expand validation as UI, extension, service, and packaging surfaces are added.
+
+## Authority and privacy
+
+Public documentation may explain Crossdock behavior and implementation. Do not reproduce private Product planning or Company policy merely for convenience. Local implementation should state the technical consequence needed to operate safely.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,21 @@
+# Code of Conduct
+
+Crossdock contributors are expected to keep project spaces professional, constructive, and focused on improving the software and its community.
+
+## Expected behavior
+
+- Treat contributors and users with respect.
+- Critique ideas, code, and designs rather than people.
+- Make room for contributors with different levels of experience and different accessibility needs.
+- Keep public discussions free of private user data, credentials, harassment, threats, and discriminatory content.
+- Respect maintainer decisions about security, privacy, scope, and repository boundaries while using normal issue/PR discussion to challenge technical or product reasoning constructively.
+
+## Unacceptable behavior
+
+Harassment, discriminatory attacks, sexualized harassment, threats, deliberate disclosure of private information, credential disclosure, spam, and sustained disruption of project spaces are not acceptable.
+
+## Enforcement
+
+Maintainers may edit, remove, lock, or moderate contributions and participation that violate these expectations. Serious or repeated violations may result in temporary or permanent exclusion from project spaces.
+
+A more formal community-governance policy may replace this baseline as the contributor community grows.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing to Crossdock
+
+Crossdock is in early public development. Contributions are welcome across implementation, browser integration, desktop/mobile UX, accessibility, documentation, graphic design, testing, packaging, and provider adapters.
+
+## Before starting
+
+- Search the public issues for existing work.
+- For a substantial new direction, open or join an issue before investing heavily so requirements and boundaries can be aligned publicly.
+- Never include private prompts, execution reports, credentials, access tokens, customer data, or Seedbed-private records in issues, fixtures, screenshots, commits, or PRs.
+
+## Development
+
+The migrated handoff core currently requires Node.js 22 or newer.
+
+```text
+npm test
+npm run check
+```
+
+As additional application surfaces land, their validation commands will be documented here and in the relevant package or directory.
+
+## Pull requests
+
+Keep changes bounded and explain:
+
+- the user/developer problem addressed;
+- the implementation approach;
+- validation performed;
+- privacy/security implications when relevant;
+- desktop/mobile implications when relevant; and
+- compatibility or migration consequences.
+
+Do not weaken fail-closed behavior, task-record integrity, or remote handoff verification merely to make automation appear successful.
+
+## Design contributions
+
+Graphic design and UX work should be attached to or linked from public issues. Prefer editable/source assets plus documented usage constraints over flattened exports alone. Designs should account for light/dark contexts, accessibility, responsive layouts, and small touch targets from the beginning.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
-# crossdock
-Crossdock
+# Crossdock
+
+Crossdock is an open-source workflow tool for moving bounded engineering work across conversation, coding-agent execution, and GitHub review without making the developer manually copy state between tools.
+
+> **Status:** early public development. The deterministic GitHub handoff core is being migrated from private incubation; the desktop/mobile application and live browser integration are not yet a supported release.
+
+## What Crossdock is building
+
+The initial route is ChatGPT → Codex Cloud → GitHub. Crossdock keeps that provider integration replaceable where practical rather than making provider names the product model.
+
+A Crossdock task can preserve the exact delegated prompt and complete execution report as one durable task record, create an initial pull request or update an existing PR branch, and independently verify that the durable GitHub handoff exists before reporting completion.
+
+Automation is a choice, not an assumption. The product is being designed to support both automatic handoff and review-before-handoff, plus configurable task-record storage so a public source repository never becomes the accidental destination for private prompts or reports.
+
+## Desktop and mobile
+
+Crossdock targets one task-centric workflow across form factors:
+
+- **Desktop:** a clean workspace with task state, external surfaces, handoff controls, errors, and history visible together where useful.
+- **Mobile:** a focused step flow with compact task state and links/deep links to external surfaces rather than three desktop panes squeezed onto a phone.
+
+Both experiences must expose the same essential state and capabilities while using layouts appropriate to the device.
+
+## Current repository contents
+
+The first public bootstrap migrates the provider-neutral parts of the existing deterministic handoff core and establishes public project documentation. Browser/Codex UI automation will move only after it is separated from Seedbed-private defaults and reviewed for public disclosure.
+
+## Documentation
+
+Start with [`docs/README.md`](docs/README.md). The documentation will grow with the implementation and currently covers the workflow model, task records, configuration direction, architecture/security boundaries, and roadmap.
+
+## Contributing
+
+Crossdock is intended for public contribution. See [`CONTRIBUTING.md`](CONTRIBUTING.md) and the public issue tracker. UX, graphic design, documentation, accessibility, adapters, packaging, and implementation work are all expected contribution areas.
+
+## Security and privacy
+
+Prompts and execution reports may contain private development context. Crossdock source is public; user task records are not therefore public. See [`SECURITY.md`](SECURITY.md) and [`docs/architecture/security-boundaries.md`](docs/architecture/security-boundaries.md).
+
+## License
+
+Crossdock will use a free/open-source GNU-family copyleft license. Exact GPL-vs-AGPL selection is being finalized before the first public release; no license grant should be inferred until the `LICENSE` file is added.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security
+
+Crossdock coordinates authenticated developer surfaces and may handle prompts and execution reports containing private development context. Treat the public source repository and user/deployment data as separate security boundaries.
+
+## Reporting vulnerabilities
+
+Do not disclose credentials, exploitable private data, or active secrets in a public issue. Until a dedicated private vulnerability-reporting channel is published, use GitHub's private vulnerability reporting feature for this repository when available.
+
+## Data-handling principles
+
+- The public Crossdock repository is not a task-log destination by default.
+- Task-record storage must be explicitly configured and appropriate for the record's confidentiality.
+- Known credentials, secrets, tokens, payment data, sensitive PII, production customer data, and equivalent forbidden material must fail closed before GitHub-backed persistence.
+- Crossdock must not extract or persist ChatGPT/Codex/GitHub session cookies as an application authentication mechanism.
+- Browser automation must fail closed when expected controls or task identity are ambiguous.
+- A handoff is not complete merely because a local action succeeded; required durable remote state must be re-read and verified.
+
+See [`docs/architecture/security-boundaries.md`](docs/architecture/security-boundaries.md) for the evolving implementation model.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,17 @@
+# Crossdock Documentation
+
+Crossdock is in early public development. These documents describe the intended workflow and the currently migrated implementation without claiming unsupported UI or provider behavior.
+
+## Start here
+
+- [`getting-started.md`](getting-started.md) — current development setup and project status.
+- [`concepts/workflow.md`](concepts/workflow.md) — task lifecycle from prompt through PR handoff.
+- [`concepts/task-records.md`](concepts/task-records.md) — durable prompt/report provenance.
+- [`concepts/adapters.md`](concepts/adapters.md) — provider boundary model.
+- [`configuration/handoff-mode.md`](configuration/handoff-mode.md) — automatic vs review-before-handoff direction.
+- [`configuration/task-log-storage.md`](configuration/task-log-storage.md) — storage privacy and configuration.
+- [`architecture/overview.md`](architecture/overview.md) — evolving technical architecture.
+- [`architecture/security-boundaries.md`](architecture/security-boundaries.md) — public source, browser sessions, credentials, and task data.
+- [`architecture/browser-integration.md`](architecture/browser-integration.md) — browser-control strategy and fail-closed requirements.
+- [`reference/task-record-schema.md`](reference/task-record-schema.md) — current implementation-level task-record schema.
+- [`roadmap.md`](roadmap.md) — public development sequence.

--- a/docs/architecture/browser-integration.md
+++ b/docs/architecture/browser-integration.md
@@ -1,0 +1,17 @@
+# Browser Integration
+
+Crossdock's initial workflow spans web applications that cannot safely be composed as ordinary cross-origin iframes with parent-page DOM control.
+
+The working architecture therefore treats the browser as an adapter surface: an extension or equivalent controlled integration can navigate/open supported pages, observe narrowly scoped state, and perform UI actions only where supported APIs cannot perform the operation reliably.
+
+## Requirements
+
+- Prefer supported provider APIs/SDKs for durable operations.
+- Isolate provider-specific selectors and state interpretation.
+- Use semantic state where available rather than coordinates or visual timing assumptions.
+- Fail closed when a required control or task identity cannot be resolved uniquely.
+- Never export authenticated session cookies as application credentials.
+- Keep the workflow core testable without a live browser.
+- Maintain compatibility tests/fixtures for provider UI changes.
+
+Live authenticated testing will resume after the public migration/bootstrap is merged and the browser adapter has been separated from Seedbed-private assumptions.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,13 @@
+# Architecture Overview
+
+Crossdock is being shaped around one workflow core with form-factor and provider adapters around it.
+
+The intended layers are:
+
+1. **Task/workflow core** — task identity, lifecycle, provenance, initial/update semantics, retry/recovery state.
+2. **Provider adapters** — conversation capture, coding-agent execution, GitHub/review operations, storage.
+3. **Local orchestration service** — coordinates authenticated adapters without exporting browser session material.
+4. **Browser integration** — controlled navigation/state observation where supported APIs do not cover the required workflow.
+5. **Responsive application UI** — desktop and mobile presentations of the same task state.
+
+The current public code is only the deterministic GitHub handoff/task-record portion of layer 1 plus a small GitHub client. The remaining layers are roadmap work and should not be inferred from directory names or documentation alone.

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -1,0 +1,23 @@
+# Security Boundaries
+
+Crossdock sits between authenticated development systems, so its security model begins with separation rather than convenience.
+
+## Public source vs private task data
+
+The Crossdock repository contains application source and public project documentation. It is not a default storage location for user prompts, reports, repository context, or operational logs.
+
+## Browser sessions
+
+Browser integrations may act inside sessions the user already authenticated, but Crossdock should not extract session cookies/tokens and turn them into its own credential store. Content scripts and browser permissions should be scoped to the minimum origins and operations required.
+
+## GitHub credentials
+
+GitHub API credentials should be narrowly scoped and stored using an appropriate local/OS credential mechanism. Tokens must not appear in task records, logs, screenshots, test fixtures, or repository configuration.
+
+## Remote completion
+
+Local success is insufficient. Crossdock must re-read durable state required by a handoff—such as the task record and its PR linkage—before declaring the operation complete.
+
+## Ambiguity
+
+Provider UI changes, multiple matching PRs, missing branch identity, unresolved storage, or uncertain controls are errors. Crossdock should stop and surface a recoverable state rather than guessing.

--- a/docs/concepts/adapters.md
+++ b/docs/concepts/adapters.md
@@ -1,0 +1,15 @@
+# Adapters
+
+Crossdock's workflow semantics should not require ChatGPT, Codex, or GitHub by name even though those are the initial integrations.
+
+Adapter boundaries are expected for:
+
+- prompt/conversation capture;
+- coding-agent task creation and status/report retrieval;
+- source-control/review operations;
+- durable task-record storage; and
+- platform-specific navigation/deep linking.
+
+An adapter translates provider state into Crossdock task state. It must not silently invent success when provider state cannot be resolved. UI adapters in particular should prefer semantic state and supported APIs over brittle coordinate or presentation-only automation.
+
+Additional providers are future compatibility work, not currently supported promises.

--- a/docs/concepts/task-records.md
+++ b/docs/concepts/task-records.md
@@ -1,0 +1,11 @@
+# Task Records
+
+A completed Crossdock execution has one immutable task record containing the exact canonical delegated prompt, complete final execution report, stable task metadata, and integrity digests.
+
+The record is execution provenance, not merge authority. It allows a reviewer or later automation to reconstruct what was delegated and what the coding agent reported without stuffing the complete transcript into every PR body.
+
+Task records may contain private development context. Their storage location is therefore explicit configuration. The public Crossdock source repository is never an implicit task-record destination.
+
+Initial tasks link the record from the PR body. Subsequent executions on the same PR branch receive distinct records and distinct top-level PR comments so earlier provenance is not overwritten.
+
+See the implementation-level schema in [`../reference/task-record-schema.md`](../reference/task-record-schema.md).

--- a/docs/concepts/workflow.md
+++ b/docs/concepts/workflow.md
@@ -1,0 +1,16 @@
+# Workflow
+
+Crossdock models one bounded engineering execution as a task rather than as a collection of browser clicks.
+
+The initial route is:
+
+1. capture or explicitly supply the engineering prompt;
+2. identify the target repository/base branch and whether the work starts a PR or updates an existing PR branch;
+3. delegate the exact canonical prompt to the configured coding-agent adapter;
+4. observe execution state and capture the complete final report;
+5. persist one immutable task record at the configured durable destination;
+6. for an initial task, create/finalize the PR body with a permanent task-record link;
+7. for an update, add a new top-level PR comment with a permanent link rather than rewriting historical provenance;
+8. re-read the required remote state and only then report the handoff complete.
+
+The workflow core should not depend on visual labels such as a particular provider's `Create PR` button. Provider adapters may use UI automation when no supported API exists, but those mechanics must remain isolated and fail closed when the expected state is ambiguous.

--- a/docs/configuration/handoff-mode.md
+++ b/docs/configuration/handoff-mode.md
@@ -1,0 +1,15 @@
+# Handoff Mode
+
+Crossdock is designed to support two user-selectable handoff modes.
+
+## Review before handoff
+
+Crossdock prepares the durable handoff and waits for explicit user approval before mutating the target GitHub review surface. This is the safer conceptual baseline while browser/provider integration is young.
+
+## Automatic
+
+After a supported coding-agent task completes and required preflight checks pass, Crossdock performs the configured durable handoff without another manual transport step.
+
+Automatic mode does not weaken validation, privacy checks, target resolution, or remote verification. Ambiguity must stop the handoff rather than trigger a guessed mutation.
+
+The end-user configuration surface and final default are not implemented yet.

--- a/docs/configuration/task-log-storage.md
+++ b/docs/configuration/task-log-storage.md
@@ -1,0 +1,14 @@
+# Task-Record Storage
+
+Task records can contain private source context, prompts, and execution reports. Crossdock therefore requires storage to be selected independently from the public application source repository.
+
+The migrated core currently supports a GitHub-backed destination expressed as an explicit repository and branch. It intentionally has no hard-coded public or Seedbed-private default.
+
+A future configuration layer may support:
+
+- a user-selected private GitHub repository;
+- a dedicated private repository configured for Crossdock records;
+- local filesystem storage with a stable linking strategy; and
+- other adapters that preserve immutable addressing, integrity, and access-control semantics.
+
+A deployment must choose a destination appropriate to the information being persisted. If the destination would expose data beyond its intended confidentiality boundary, persistence should fail closed rather than silently downgrade privacy.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,27 @@
+# Getting Started
+
+Crossdock does not yet have an end-user release. This guide currently covers contributor setup for the migrated handoff core.
+
+## Requirements
+
+- Node.js 22 or newer
+- Git
+
+## Development
+
+Clone the repository, then run:
+
+```text
+npm test
+npm run check
+```
+
+The current code has no third-party runtime dependencies.
+
+## What works today
+
+The migrated core can deterministically render task records, reject several known secret-like patterns before GitHub persistence, construct initial PR/update-comment provenance, use an explicitly configured GitHub task-record repository, and verify the durable remote state through its GitHub client abstraction.
+
+## What does not exist yet
+
+A supported desktop/mobile UI, installation package, authenticated end-user setup flow, production storage configuration UI, and hardened live ChatGPT/Codex browser adapter are still under development. Track those items in the public issue backlog rather than treating this bootstrap as a release.

--- a/docs/reference/task-record-schema.md
+++ b/docs/reference/task-record-schema.md
@@ -1,0 +1,47 @@
+# Crossdock Task Record Schema
+
+Schema identifier: `crossdock.task-record/v1`
+
+A task record is an immutable Markdown record of one completed coding-agent execution.
+
+## Path
+
+```text
+crossdock/tasks/<target-owner>/<target-repo>/<yyyy>/<mm>/<task-id>.md
+```
+
+Existing records must not be overwritten. Corrections or follow-up executions create new task records.
+
+## Structure
+
+Each record uses YAML front matter followed by the exact canonical prompt and complete execution report. Current fields are:
+
+- `schema`
+- `task_id`
+- `task_type` (`initial` or `update`)
+- `status`
+- `created_at`
+- `completed_at`
+- `target_repository`
+- `base_branch`
+- `working_branch`
+- `pull_request`
+- `issue`
+- `agent_task_url`
+- `result_commit`
+- `parent_task_id`
+- `prompt_sha256`
+- `report_sha256`
+
+## Invariants
+
+1. Prompt and report text is canonicalized to UTF-8/LF semantics before hashing/rendering.
+2. `prompt_sha256` and `report_sha256` are SHA-256 digests of their canonical text.
+3. Initial tasks have no parent task.
+4. Update tasks identify a pull request and should identify their preceding related task when known.
+5. Known secret-like material must fail closed before GitHub-backed persistence.
+6. Storage is explicitly configured and must be appropriate for the data's confidentiality.
+7. Initial task records are linked from the PR body; later update records are linked from new top-level PR comments rather than rewriting earlier provenance.
+8. Durable task record and PR linkage are remotely re-read before a handoff is reported complete.
+
+Readers should reject unknown major schema versions unless they explicitly support them. Additive compatible metadata may be introduced later without weakening these invariants.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,41 @@
+# Roadmap
+
+Crossdock is pre-release. The current public sequence is intentionally capability-based rather than date-promised.
+
+## Bootstrap
+
+- migrate and de-Seedbed the deterministic handoff/task-record core;
+- establish public docs, contribution/security guidance, and issue backlog;
+- settle and add the open-source license.
+
+## Workflow foundation
+
+- explicit configuration model;
+- pluggable task-record storage;
+- automatic and review-before-handoff state machine;
+- task history/recovery semantics;
+- provider adapter contracts.
+
+## User experience
+
+- responsive desktop workspace;
+- phone-first mobile workflow;
+- accessibility baseline;
+- status/error/recovery UX;
+- installation/onboarding flow.
+
+## Integration hardening
+
+- browser extension/service boundary;
+- ChatGPT/Codex live adapter compatibility;
+- GitHub authentication and least-privilege setup;
+- compatibility fixtures and provider-change recovery.
+
+## Distribution
+
+- desktop packaging decision and supported platforms;
+- mobile/PWA/native-shell decision;
+- release/compatibility policy;
+- first contributor-facing release.
+
+The issue tracker is the executable public work queue; this document is a navigational summary rather than a commitment to dates or ordering when dependencies change.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@seedbed-ai/crossdock",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "test": "node --test",
+    "check": "node --check src/github-client.js && node --check src/handoff.js && node --check src/index.js && node --check src/task-log.js && node --check tests/github-client.test.js && node --check tests/handoff.test.js && node --check tests/task-log.test.js"
+  }
+}

--- a/src/github-client.js
+++ b/src/github-client.js
@@ -1,0 +1,80 @@
+export class GitHubClient {
+  constructor({ token, fetchImpl = globalThis.fetch, apiBase = "https://api.github.com" } = {}) {
+    if (!token) throw new Error("GitHub token is required");
+    if (typeof fetchImpl !== "function") throw new Error("fetch implementation is required");
+    this.token = token;
+    this.fetchImpl = fetchImpl;
+    this.apiBase = apiBase.replace(/\/$/, "");
+  }
+
+  async request(method, path, body) {
+    const response = await this.fetchImpl(`${this.apiBase}${path}`, {
+      method,
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${this.token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+
+    const text = await response.text();
+    const payload = text ? JSON.parse(text) : null;
+    if (!response.ok) {
+      const error = new Error(`GitHub ${method} ${path} failed: ${response.status}`);
+      error.status = response.status;
+      error.payload = payload;
+      throw error;
+    }
+    return payload;
+  }
+
+  createFile(repository, path, content, message, branch) {
+    const [owner, repo] = repository.split("/");
+    return this.request("PUT", `/repos/${owner}/${repo}/contents/${encodePath(path)}`, {
+      message,
+      content: Buffer.from(content, "utf8").toString("base64"),
+      ...(branch ? { branch } : {}),
+    });
+  }
+
+  getFile(repository, path, ref) {
+    const [owner, repo] = repository.split("/");
+    const query = ref ? `?ref=${encodeURIComponent(ref)}` : "";
+    return this.request("GET", `/repos/${owner}/${repo}/contents/${encodePath(path)}${query}`);
+  }
+
+  createPullRequest(repository, { title, body, head, base, draft = false }) {
+    const [owner, repo] = repository.split("/");
+    return this.request("POST", `/repos/${owner}/${repo}/pulls`, { title, body, head, base, draft });
+  }
+
+  updatePullRequest(repository, number, { title, body, state, base }) {
+    const [owner, repo] = repository.split("/");
+    return this.request("PATCH", `/repos/${owner}/${repo}/pulls/${number}`, compact({ title, body, state, base }));
+  }
+
+  getPullRequest(repository, number) {
+    const [owner, repo] = repository.split("/");
+    return this.request("GET", `/repos/${owner}/${repo}/pulls/${number}`);
+  }
+
+  addIssueComment(repository, number, body) {
+    const [owner, repo] = repository.split("/");
+    return this.request("POST", `/repos/${owner}/${repo}/issues/${number}/comments`, { body });
+  }
+
+  getIssueComments(repository, number) {
+    const [owner, repo] = repository.split("/");
+    return this.request("GET", `/repos/${owner}/${repo}/issues/${number}/comments?per_page=100`);
+  }
+}
+
+function encodePath(path) {
+  return path.split("/").map(encodeURIComponent).join("/");
+}
+
+function compact(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined));
+}

--- a/src/handoff.js
+++ b/src/handoff.js
@@ -1,0 +1,73 @@
+import { renderTaskLog, taskLogPath, validateTaskRecord } from "./task-log.js";
+
+export function buildPrBody({ summary, validation = [], issue, logUrl, branch, commit }) {
+  const lines = ["## Summary", "", summary.trim(), ""];
+  if (validation.length) lines.push("## Validation", "", ...validation.map((item) => `- ${item}`), "");
+  lines.push("## Crossdock", "", `Task record: ${logUrl}`);
+  if (branch) lines.push(`Branch: \`${branch}\``);
+  if (commit) lines.push(`Commit: \`${commit}\``);
+  if (issue) lines.push("", `Closes #${issue}`);
+  return `${lines.join("\n")}\n`;
+}
+
+export function buildUpdateComment({ summary, validation = [], logUrl, commit }) {
+  const lines = ["## Crossdock branch update", "", summary.trim(), ""];
+  if (validation.length) lines.push(...validation.map((item) => `- ${item}`));
+  if (commit) lines.push(`- Commit: \`${commit}\``);
+  lines.push(`- Task record: ${logUrl}`);
+  return `${lines.join("\n")}\n`;
+}
+
+export async function publishInitialHandoff({ github, storage, task, pr }) {
+  const destination = requireStorage(storage);
+  validateTaskRecord({ ...task, task_type: "initial", pull_request: null, parent_task_id: null });
+  const createdPr = await github.createPullRequest(task.target_repository, {
+    title: pr.title, body: pr.provisionalBody ?? pr.summary, head: task.working_branch, base: task.base_branch, draft: pr.draft ?? false,
+  });
+  const record = { ...task, task_type: "initial", pull_request: createdPr.number, parent_task_id: null };
+  const persisted = await persistTaskLog({ github, storage: destination, record });
+  const body = buildPrBody({ summary: pr.summary, validation: pr.validation, issue: task.issue, logUrl: persisted.url, branch: task.working_branch, commit: task.result_commit });
+  await github.updatePullRequest(task.target_repository, createdPr.number, { body });
+  const verified = await github.getPullRequest(task.target_repository, createdPr.number);
+  if (!verified.body?.includes(persisted.url)) throw new Error("initial handoff verification failed: PR body does not link task record");
+  await verifyTaskLog({ github, storage: destination, path: persisted.path, ref: persisted.commitSha, expectedContent: persisted.content });
+  return { pullRequest: verified, taskLog: persisted };
+}
+
+export async function publishUpdateHandoff({ github, storage, task, update }) {
+  const destination = requireStorage(storage);
+  const record = { ...task, task_type: "update" };
+  const persisted = await persistTaskLog({ github, storage: destination, record });
+  const commentBody = buildUpdateComment({ summary: update.summary, validation: update.validation, logUrl: persisted.url, commit: task.result_commit });
+  const comment = await github.addIssueComment(task.target_repository, task.pull_request, commentBody);
+  const comments = await github.getIssueComments(task.target_repository, task.pull_request);
+  const verifiedComment = comments.find((item) => item.id === comment.id);
+  if (!verifiedComment?.body?.includes(persisted.url)) throw new Error("update handoff verification failed: durable PR comment does not link task record");
+  await verifyTaskLog({ github, storage: destination, path: persisted.path, ref: persisted.commitSha, expectedContent: persisted.content });
+  return { comment: verifiedComment, taskLog: persisted };
+}
+
+export async function persistTaskLog({ github, storage, record }) {
+  const destination = requireStorage(storage);
+  const path = taskLogPath(record);
+  const content = renderTaskLog(record);
+  const response = await github.createFile(destination.repository, path, content, `crossdock: record task ${record.task_id}`, destination.branch);
+  const commitSha = response.commit?.sha;
+  if (!commitSha) throw new Error("task-record persistence did not return a commit SHA");
+  const url = `https://github.com/${destination.repository}/blob/${commitSha}/${path}`;
+  return { path, content, commitSha, url };
+}
+
+function requireStorage(storage) {
+  if (!storage || typeof storage !== "object") throw new Error("task-record storage must be configured explicitly");
+  if (!/^[^/]+\/[^/]+$/.test(storage.repository ?? "")) throw new Error("storage.repository must be owner/repo");
+  if (typeof storage.branch !== "string" || !storage.branch) throw new Error("storage.branch is required");
+  return storage;
+}
+
+async function verifyTaskLog({ github, storage, path, ref, expectedContent }) {
+  const file = await github.getFile(storage.repository, path, ref);
+  if (!file?.sha || typeof file.content !== "string") throw new Error("task-record verification failed: remote file missing content");
+  const actual = Buffer.from(file.content.replace(/\n/g, ""), "base64").toString("utf8");
+  if (actual !== expectedContent) throw new Error("task-record verification failed: remote content mismatch");
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,3 @@
+export { GitHubClient } from "./github-client.js";
+export { buildPrBody, buildUpdateComment, persistTaskLog, publishInitialHandoff, publishUpdateHandoff } from "./handoff.js";
+export { TASK_LOG_SCHEMA, assertGithubSafe, canonicalizeText, renderTaskLog, sha256, taskLogPath, validateTaskRecord } from "./task-log.js";

--- a/src/task-log.js
+++ b/src/task-log.js
@@ -1,0 +1,89 @@
+import { createHash } from "node:crypto";
+
+export const TASK_LOG_SCHEMA = "crossdock.task-record/v1";
+
+const FORBIDDEN_PATTERNS = [
+  /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/i,
+  /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/,
+  /\bsk-[A-Za-z0-9_-]{20,}\b/,
+  /\bAKIA[0-9A-Z]{16}\b/,
+  /\b(?:password|passwd|api[_-]?key|access[_-]?token|secret)\s*[:=]\s*[^\s]{8,}/i,
+];
+
+export function canonicalizeText(value) {
+  if (typeof value !== "string") throw new TypeError("text must be a string");
+  return value.replace(/\r\n?/g, "\n");
+}
+
+export function sha256(value) {
+  return createHash("sha256").update(canonicalizeText(value), "utf8").digest("hex");
+}
+
+export function assertGithubSafe(value, label = "content") {
+  const canonical = canonicalizeText(value);
+  for (const pattern of FORBIDDEN_PATTERNS) {
+    if (pattern.test(canonical)) throw new Error(`${label} appears to contain Forbidden-from-GitHub material`);
+  }
+}
+
+function quoteYaml(value) {
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "number") return String(value);
+  return JSON.stringify(String(value));
+}
+
+function requireString(record, field) {
+  if (typeof record[field] !== "string" || record[field].length === 0) throw new Error(`${field} is required`);
+}
+
+function assertTimestamp(value, field) {
+  requireString({ [field]: value }, field);
+  if (Number.isNaN(Date.parse(value))) throw new Error(`${field} must be an RFC 3339 timestamp`);
+}
+
+export function validateTaskRecord(record) {
+  if (!record || typeof record !== "object") throw new TypeError("record is required");
+  requireString(record, "task_id");
+  requireString(record, "target_repository");
+  requireString(record, "base_branch");
+  requireString(record, "working_branch");
+  requireString(record, "prompt");
+  requireString(record, "report");
+  assertTimestamp(record.created_at, "created_at");
+  assertTimestamp(record.completed_at, "completed_at");
+
+  if (!/^[^/]+\/[^/]+$/.test(record.target_repository)) throw new Error("target_repository must be owner/repo");
+  if (!/^[A-Za-z0-9._-]+$/.test(record.task_id)) throw new Error("task_id may contain only letters, numbers, dot, underscore, and hyphen");
+  if (!["initial", "update"].includes(record.task_type)) throw new Error("task_type must be initial or update");
+  if (record.task_type === "initial" && record.parent_task_id != null) throw new Error("initial task parent_task_id must be null");
+  if (record.task_type === "update" && !record.pull_request) throw new Error("update task requires pull_request");
+
+  assertGithubSafe(record.prompt, "prompt");
+  assertGithubSafe(record.report, "report");
+  return record;
+}
+
+export function taskLogPath(record) {
+  validateTaskRecord(record);
+  const completed = new Date(record.completed_at);
+  const year = String(completed.getUTCFullYear());
+  const month = String(completed.getUTCMonth() + 1).padStart(2, "0");
+  const [owner, repo] = record.target_repository.split("/");
+  return `crossdock/tasks/${owner}/${repo}/${year}/${month}/${record.task_id}.md`;
+}
+
+export function renderTaskLog(record) {
+  validateTaskRecord(record);
+  const prompt = canonicalizeText(record.prompt);
+  const report = canonicalizeText(record.report);
+  const fields = [
+    ["schema", TASK_LOG_SCHEMA], ["task_id", record.task_id], ["task_type", record.task_type], ["status", "completed"],
+    ["created_at", record.created_at], ["completed_at", record.completed_at], ["target_repository", record.target_repository],
+    ["base_branch", record.base_branch], ["working_branch", record.working_branch], ["pull_request", record.pull_request ?? null],
+    ["issue", record.issue ?? null], ["agent_task_url", record.agent_task_url ?? record.codex_task_url ?? null],
+    ["result_commit", record.result_commit ?? null], ["parent_task_id", record.parent_task_id ?? null],
+    ["prompt_sha256", sha256(prompt)], ["report_sha256", sha256(report)],
+  ];
+  const frontMatter = fields.map(([key, value]) => `${key}: ${quoteYaml(value)}`).join("\n");
+  return `---\n${frontMatter}\n---\n\n# Crossdock Task\n\n## Prompt\n\n${prompt}\n\n## Report\n\n${report}\n`;
+}

--- a/tests/github-client.test.js
+++ b/tests/github-client.test.js
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { GitHubClient } from "../src/github-client.js";
+function response(status, payload) { return { ok: status >= 200 && status < 300, status, async text() { return payload == null ? "" : JSON.stringify(payload); } }; }
+
+test("GitHubClient creates UTF-8 files with base64 content", async () => {
+  const calls = []; const client = new GitHubClient({ token: "test-token", fetchImpl: async (url, options) => { calls.push([url, options]); return response(201, { commit: { sha: "abc123" } }); } });
+  await client.createFile("example/private-task-records", "crossdock/tasks/a b.md", "hello", "record task", "main");
+  const [url, options] = calls[0]; assert.equal(url, "https://api.github.com/repos/example/private-task-records/contents/crossdock/tasks/a%20b.md"); assert.equal(options.method, "PUT"); assert.equal(options.headers.Authorization, "Bearer test-token");
+});
+
+test("GitHubClient exposes GitHub error status and payload", async () => {
+  const client = new GitHubClient({ token: "test-token", fetchImpl: async () => response(422, { message: "Validation Failed" }) });
+  await assert.rejects(client.getPullRequest("example/project", 1), (error) => error.status === 422 && error.payload.message === "Validation Failed");
+});

--- a/tests/handoff.test.js
+++ b/tests/handoff.test.js
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { publishInitialHandoff, publishUpdateHandoff } from "../src/handoff.js";
+
+const storage = { repository: "example/private-task-records", branch: "main" };
+function task(overrides = {}) { return { task_id: "task-001", created_at: "2026-08-31T20:00:00Z", completed_at: "2026-08-31T20:05:00Z", target_repository: "example/project", base_branch: "main", working_branch: "crossdock/task-001", issue: 123, agent_task_url: "https://example.invalid/tasks/task-001", result_commit: "0123456789abcdef0123456789abcdef01234567", prompt: "Implement the bounded task.", report: "## Summary\n\nImplemented and validated.", ...overrides }; }
+function mockGithub() {
+  const calls = []; let prBody = null; let storedContent = null; let storedComment = null;
+  return { calls,
+    async createPullRequest(repository, payload) { calls.push(["createPullRequest", repository, payload]); prBody = payload.body; return { number: 77, body: prBody }; },
+    async createFile(repository, path, content, message, branch) { calls.push(["createFile", repository, path, content, message, branch]); storedContent = content; return { commit: { sha: "abc123" }, content: { sha: "blob123" } }; },
+    async updatePullRequest(repository, number, payload) { calls.push(["updatePullRequest", repository, number, payload]); prBody = payload.body; return { number, body: prBody }; },
+    async getPullRequest(repository, number) { calls.push(["getPullRequest", repository, number]); return { number, body: prBody }; },
+    async getFile(repository, path, ref) { calls.push(["getFile", repository, path, ref]); return { sha: "blob123", content: Buffer.from(storedContent, "utf8").toString("base64") }; },
+    async addIssueComment(repository, number, body) { calls.push(["addIssueComment", repository, number, body]); storedComment = { id: 9, body }; return storedComment; },
+    async getIssueComments(repository, number) { calls.push(["getIssueComments", repository, number]); return storedComment ? [storedComment] : []; },
+  };
+}
+
+test("storage must be explicit before mutation", async () => { const github = mockGithub(); await assert.rejects(publishInitialHandoff({ github, task: task(), pr: { title: "change", summary: "summary" } }), /storage must be configured explicitly/); assert.deepEqual(github.calls, []); });
+
+test("initial handoff persists configured record and verifies", async () => { const github = mockGithub(); const result = await publishInitialHandoff({ github, storage, task: task(), pr: { title: "test: bounded change", summary: "Implements the bounded change.", validation: ["tests passed"] } }); assert.equal(result.pullRequest.number, 77); assert.equal(result.taskLog.url, "https://github.com/example/private-task-records/blob/abc123/crossdock/tasks/example/project/2026/08/task-001.md"); assert.match(result.pullRequest.body, /Task record:/); assert.deepEqual(github.calls.map(([name]) => name), ["createPullRequest", "createFile", "updatePullRequest", "getPullRequest", "getFile"]); });
+
+test("forbidden content fails before PR creation", async () => { const github = mockGithub(); await assert.rejects(publishInitialHandoff({ github, storage, task: task({ prompt: "access_token=ghp_abcdefghijklmnopqrstuvwxyz123456" }), pr: { title: "change", summary: "summary" } }), /Forbidden-from-GitHub/); assert.deepEqual(github.calls, []); });
+
+test("update handoff adds a new top-level comment without editing PR", async () => { const github = mockGithub(); const result = await publishUpdateHandoff({ github, storage, task: task({ task_id: "task-002", pull_request: 77, parent_task_id: "task-001" }), update: { summary: "Addressed review findings.", validation: ["tests passed"] } }); assert.match(result.comment.body, /Crossdock branch update/); assert.ok(!github.calls.some(([name]) => name === "updatePullRequest")); });

--- a/tests/task-log.test.js
+++ b/tests/task-log.test.js
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { canonicalizeText, renderTaskLog, sha256, taskLogPath } from "../src/task-log.js";
+
+function baseRecord(overrides = {}) {
+  return {
+    task_id: "task-001", task_type: "initial", created_at: "2026-08-31T20:00:00Z", completed_at: "2026-08-31T20:05:00Z",
+    target_repository: "example/project", base_branch: "main", working_branch: "crossdock/task-001", pull_request: 42, issue: 123,
+    agent_task_url: "https://example.invalid/tasks/task-001", result_commit: "0123456789abcdef0123456789abcdef01234567", parent_task_id: null,
+    prompt: "Do the thing.\r\nPreserve invariants.\r\n", report: "## Summary\r\n\r\nDone.\r\n", ...overrides,
+  };
+}
+
+test("canonicalizeText normalizes CRLF and CR to LF", () => assert.equal(canonicalizeText("a\r\nb\rc\n"), "a\nb\nc\n"));
+
+test("renderTaskLog preserves canonical prompt and report with digests", () => {
+  const record = baseRecord(); const rendered = renderTaskLog(record);
+  assert.match(rendered, /schema: "crossdock\.task-record\/v1"/);
+  assert.match(rendered, new RegExp(`prompt_sha256: "${sha256(record.prompt)}"`));
+  assert.match(rendered, new RegExp(`report_sha256: "${sha256(record.report)}"`));
+  assert.match(rendered, /## Prompt\n\nDo the thing\.\nPreserve invariants\.\n/);
+  assert.match(rendered, /## Report\n\n## Summary\n\nDone\.\n/);
+  assert.ok(!rendered.includes("\r"));
+});
+
+test("taskLogPath is deterministic", () => assert.equal(taskLogPath(baseRecord()), "crossdock/tasks/example/project/2026/08/task-001.md"));
+
+test("update tasks require a pull request", () => assert.throws(() => renderTaskLog(baseRecord({ task_type: "update", pull_request: null, parent_task_id: "task-001" })), /update task requires pull_request/));
+
+test("known secret-like material fails closed", () => assert.throws(() => renderTaskLog(baseRecord({ prompt: "access_token=ghp_abcdefghijklmnopqrstuvwxyz123456" })), /Forbidden-from-GitHub/));


### PR DESCRIPTION
## Summary

- establishes Crossdock's public README, contributor/security/community guidance, documentation index, architecture/concepts/configuration references, roadmap, and GitHub templates
- migrates the deterministic GitHub handoff/task-record core from private `seedbed-ai/dev-tools`
- removes the reusable core's hard-coded `seedbed-ai/dev-tools` task-log destination and requires explicit storage configuration
- renames implementation-level provenance from Seedbed/Codex-specific task logs to provider-neutral Crossdock task records
- keeps live browser/Codex adapter work out of this bootstrap until private assumptions are separated and reviewed

## Privacy

No private Seedbed task logs, Product planning, credentials, or operational data are migrated. The public source repository is explicitly not a default task-record destination.

## License

No `LICENSE` file is added yet because Company #25 still owns the exact AGPL-vs-GPL disposition.

## Validation

The migrated code retains Node's dependency-free test/check setup. Remote diff review will be performed before merge.