### PR TITLE
feat: migrate public browser adapter and handoff service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
       - run: npm test
       - run: npm run check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm test
+      - run: npm run check

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,5 +13,6 @@ Crossdock is in early public development. These documents describe the intended 
 - [`architecture/overview.md`](architecture/overview.md) — evolving technical architecture.
 - [`architecture/security-boundaries.md`](architecture/security-boundaries.md) — public source, browser sessions, credentials, and task data.
 - [`architecture/browser-integration.md`](architecture/browser-integration.md) — browser-control strategy and fail-closed requirements.
+- [`architecture/live-testing.md`](architecture/live-testing.md) — authenticated provider validation checklist and failure cases.
 - [`reference/task-record-schema.md`](reference/task-record-schema.md) — current implementation-level task-record schema.
 - [`roadmap.md`](roadmap.md) — public development sequence.

--- a/docs/architecture/live-testing.md
+++ b/docs/architecture/live-testing.md
@@ -1,0 +1,27 @@
+# Live Adapter Validation
+
+The browser adapter is intentionally fail closed and must be validated against the authenticated provider UI before Crossdock claims a supported integration.
+
+## Initial-task validation
+
+Verify that Crossdock can:
+
+1. identify exactly one ordinary ChatGPT tab and capture the intended latest assistant response;
+2. identify exactly one Codex task surface and submit the exact captured prompt;
+3. detect completion only when the task exposes the expected durable handoff state;
+4. capture the complete final Codex report rather than an intermediate assistant message;
+5. invoke `Create PR` only when it resolves uniquely;
+6. identify the resulting target-repository PR URL;
+7. hydrate base branch, head branch, and head SHA from GitHub rather than browser assumptions;
+8. persist the immutable task record to the explicitly configured destination;
+9. update and re-read the existing PR body with the task-record link.
+
+## Branch-update validation
+
+Verify that Crossdock snapshots the PR head before the update, invokes `Update branch` only when unique, waits until GitHub reports a different head SHA, persists a new task record, and creates a new top-level PR comment without rewriting the original PR body merely for later provenance.
+
+## Failure cases
+
+Exercise multiple matching tabs, missing/duplicate buttons, changed semantic selectors, missing report content, invalid storage, stale PR identity, localhost service unavailability, and task/browser restart recovery. Each case must produce a recoverable error rather than a guessed mutation.
+
+Passing syntax/unit/HTTP-boundary CI is necessary but not sufficient for provider support. Live compatibility evidence should be recorded with the provider UI/version/date observed and converted into fixtures/tests where practical.

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,123 @@
+const CHATGPT_URL = "https://chatgpt.com/";
+const CODEX_URL = "https://chatgpt.com/codex/cloud";
+const DASHBOARD_URL = chrome.runtime.getURL("dashboard.html");
+
+chrome.action.onClicked.addListener(() => void openDashboard());
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  void handleMessage(message)
+    .then((result) => sendResponse({ ok: true, result }))
+    .catch((error) => sendResponse({ ok: false, error: error.message }));
+  return true;
+});
+
+async function handleMessage(message) {
+  switch (message.type) {
+    case "crossdock.capturePrompt": {
+      const tab = await findChatGptTab(false);
+      return sendToTab(tab.id, { type: "crossdock.capturePrompt" });
+    }
+    case "crossdock.submitCodex": {
+      const tab = await ensureCodexTab();
+      const result = await sendToTab(tab.id, { type: "crossdock.submitCodex", prompt: message.prompt });
+      await chrome.tabs.update(tab.id, { active: true });
+      return result;
+    }
+    case "crossdock.inspectCodex": {
+      const tab = await findChatGptTab(true);
+      return sendToTab(tab.id, { type: "crossdock.inspectCodex" });
+    }
+    case "crossdock.createPrAndInspect": {
+      const tab = await findChatGptTab(true);
+      const beforeTabs = new Set(await matchingPrTabUrls(message.targetRepository));
+      const beforePage = new Set((await sendToTab(tab.id, { type: "crossdock.findPrUrls", targetRepository: message.targetRepository })).prUrls);
+      const prepared = await sendToTab(tab.id, { type: "crossdock.prepareCreatePr" });
+      const prUrl = await waitForPrUrl({ tabId: tab.id, targetRepository: message.targetRepository, beforeTabs, beforePage });
+      return { ...prepared, prUrl };
+    }
+    case "crossdock.applyBranchUpdate": {
+      const tab = await findChatGptTab(true);
+      return sendToTab(tab.id, { type: "crossdock.prepareBranchUpdate" });
+    }
+    case "crossdock.openChatGPT": return activateOrCreate(CHATGPT_URL, false);
+    case "crossdock.openCodex": return activateOrCreate(CODEX_URL, true);
+    case "crossdock.openGitHub":
+      if (!message.url?.startsWith("https://github.com/")) throw new Error("invalid GitHub URL");
+      return activateOrCreate(message.url, null);
+    default: throw new Error(`unsupported background message: ${message.type}`);
+  }
+}
+
+async function openDashboard() {
+  const dashboards = (await chrome.tabs.query({})).filter((tab) => tab.url === DASHBOARD_URL);
+  if (dashboards.length > 1) throw new Error(`dashboard tab is ambiguous; found ${dashboards.length}`);
+  if (dashboards.length === 1) return chrome.tabs.update(dashboards[0].id, { active: true });
+  return chrome.tabs.create({ url: DASHBOARD_URL, active: true });
+}
+
+async function findChatGptTab(codex) {
+  const tabs = await chrome.tabs.query({ url: "https://chatgpt.com/*" });
+  const filtered = tabs.filter((tab) => new URL(tab.url).pathname.startsWith("/codex") === codex);
+  if (filtered.length !== 1) throw new Error(`${codex ? "Codex" : "ChatGPT"} tab must resolve to exactly one open tab; found ${filtered.length}`);
+  return filtered[0];
+}
+
+async function ensureCodexTab() {
+  const tabs = await chrome.tabs.query({ url: "https://chatgpt.com/codex/*" });
+  if (tabs.length > 1) throw new Error(`Codex tab is ambiguous; found ${tabs.length}`);
+  if (tabs.length === 1) return tabs[0];
+  const tab = await chrome.tabs.create({ url: CODEX_URL, active: true });
+  await waitForTabComplete(tab.id);
+  return chrome.tabs.get(tab.id);
+}
+
+async function activateOrCreate(url, codex) {
+  if (codex === true) {
+    const tab = await ensureCodexTab();
+    return chrome.tabs.update(tab.id, { active: true });
+  }
+  if (codex === false) {
+    const ordinary = (await chrome.tabs.query({ url: "https://chatgpt.com/*" })).filter((tab) => !new URL(tab.url).pathname.startsWith("/codex"));
+    if (ordinary.length > 1) throw new Error(`ChatGPT tab is ambiguous; found ${ordinary.length}`);
+    if (ordinary.length === 1) return chrome.tabs.update(ordinary[0].id, { active: true });
+  }
+  return chrome.tabs.create({ url, active: true });
+}
+
+async function waitForPrUrl({ tabId, targetRepository, beforeTabs, beforePage }) {
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    const tabUrls = await matchingPrTabUrls(targetRepository);
+    const newTabUrl = tabUrls.find((url) => !beforeTabs.has(url));
+    if (newTabUrl) return newTabUrl;
+    try {
+      const current = await sendToTab(tabId, { type: "crossdock.findPrUrls", targetRepository });
+      const newPageUrl = current.prUrls.find((url) => !beforePage.has(url));
+      if (newPageUrl) return newPageUrl;
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error("timed out waiting for coding-agent-created PR URL");
+}
+
+async function matchingPrTabUrls(targetRepository) {
+  const prefix = `https://github.com/${targetRepository}/pull/`;
+  return (await chrome.tabs.query({ url: "https://github.com/*/*/pull/*" })).map((tab) => tab.url).filter((url) => url?.startsWith(prefix));
+}
+
+async function sendToTab(tabId, message) {
+  const response = await chrome.tabs.sendMessage(tabId, message);
+  if (!response?.ok) throw new Error(response?.error ?? "content adapter failed");
+  return response.result;
+}
+
+function waitForTabComplete(tabId) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => { chrome.tabs.onUpdated.removeListener(listener); reject(new Error("timed out waiting for Codex tab to load")); }, 30_000);
+    const listener = (updatedId, info) => {
+      if (updatedId !== tabId || info.status !== "complete") return;
+      clearTimeout(timeout); chrome.tabs.onUpdated.removeListener(listener); resolve();
+    };
+    chrome.tabs.onUpdated.addListener(listener);
+  });
+}

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,113 @@
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  void handleMessage(message)
+    .then((result) => sendResponse({ ok: true, result }))
+    .catch((error) => sendResponse({ ok: false, error: error.message }));
+  return true;
+});
+
+async function handleMessage(message) {
+  switch (message.type) {
+    case "crossdock.capturePrompt": return { prompt: captureLatestAssistantMessage(), url: location.href };
+    case "crossdock.submitCodex": return submitCodexPrompt(message.prompt);
+    case "crossdock.inspectCodex": return inspectCodexTask();
+    case "crossdock.findPrUrls": return { prUrls: findPullRequestLinks(message.targetRepository) };
+    case "crossdock.prepareCreatePr": return prepareCreatePr();
+    case "crossdock.prepareBranchUpdate": return prepareBranchUpdate();
+    default: throw new Error(`unsupported content message: ${message.type}`);
+  }
+}
+
+function captureLatestAssistantMessage() {
+  const nodes = [...document.querySelectorAll('[data-message-author-role="assistant"]')]
+    .filter(isVisible).map((node) => normalizeText(node.innerText)).filter(Boolean);
+  if (!nodes.length) throw new Error("no visible ChatGPT assistant message found");
+  return nodes.at(-1);
+}
+
+function submitCodexPrompt(prompt) {
+  requireCodexPage();
+  if (typeof prompt !== "string" || !prompt.trim()) throw new Error("Codex prompt is empty");
+  const input = findUniqueVisible(["textarea", '[contenteditable="true"][role="textbox"]', '[contenteditable="true"][data-placeholder]'], "Codex prompt input");
+  setEditableValue(input, prompt);
+  findUniqueButton(["Create task", "Start task", "Run task", "Submit"]).click();
+  return { taskUrl: location.href };
+}
+
+function inspectCodexTask() {
+  requireCodexPage();
+  return { taskUrl: location.href, createPrAvailable: Boolean(findButton(["Create PR"], false)), updateBranchAvailable: Boolean(findButton(["Update branch"], false)) };
+}
+
+function prepareCreatePr() {
+  requireCodexPage();
+  const result = { taskUrl: location.href, report: captureCodexReport() };
+  findButton(["Create PR"], true).click();
+  return result;
+}
+
+function prepareBranchUpdate() {
+  requireCodexPage();
+  const result = { taskUrl: location.href, report: captureCodexReport() };
+  findButton(["Update branch"], true).click();
+  return result;
+}
+
+function captureCodexReport() {
+  const selectors = ['[data-testid="codex-task-report"]', '[data-testid*="final-report"]', '[data-testid*="task-report"]', '[data-message-author-role="assistant"]'];
+  const candidates = selectors.flatMap((selector) => [...document.querySelectorAll(selector)])
+    .filter(isVisible).map((node) => normalizeText(node.innerText)).filter(Boolean);
+  if (!candidates.length) throw new Error("unable to identify the complete Codex report from known semantic selectors");
+  return candidates.at(-1);
+}
+
+function findPullRequestLinks(targetRepository) {
+  const prefix = targetRepository ? `https://github.com/${targetRepository}/pull/` : "https://github.com/";
+  return [...document.querySelectorAll('a[href*="github.com/"]')].filter(isVisible).map((anchor) => anchor.href)
+    .filter((href) => href.startsWith(prefix) && /\/pull\/\d+(?:$|[?#])/.test(href));
+}
+
+function findUniqueVisible(selectors, label) {
+  const nodes = [...new Set(selectors.flatMap((selector) => [...document.querySelectorAll(selector)]))].filter(isVisible);
+  if (nodes.length !== 1) throw new Error(`${label} must resolve to exactly one visible element; found ${nodes.length}`);
+  return nodes[0];
+}
+
+function findUniqueButton(labels) {
+  const button = findButton(labels, false);
+  if (!button) throw new Error(`no unique visible button found for: ${labels.join(", ")}`);
+  return button;
+}
+
+function findButton(labels, required) {
+  const normalizedLabels = new Set(labels.map((label) => label.toLowerCase()));
+  const buttons = [...document.querySelectorAll('button, [role="button"]')]
+    .filter(isVisible).filter((node) => normalizedLabels.has(accessibleText(node).toLowerCase()));
+  if (buttons.length > 1) throw new Error(`button selector is ambiguous for: ${labels.join(", ")}`);
+  if (required && buttons.length !== 1) throw new Error(`required button not found: ${labels.join(", ")}`);
+  return buttons[0] ?? null;
+}
+
+function setEditableValue(node, value) {
+  node.focus();
+  if (node instanceof HTMLTextAreaElement || node instanceof HTMLInputElement) {
+    const descriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(node), "value");
+    if (!descriptor?.set) throw new Error("Codex prompt input value setter is unavailable");
+    descriptor.set.call(node, value);
+    node.dispatchEvent(new Event("input", { bubbles: true }));
+    node.dispatchEvent(new Event("change", { bubbles: true }));
+    if (node.value !== value) throw new Error("Codex prompt input did not retain the submitted prompt");
+    return;
+  }
+  if (node.isContentEditable) {
+    node.textContent = value;
+    node.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText", data: value }));
+    if (node.textContent !== value) throw new Error("Codex prompt input did not retain the submitted prompt");
+    return;
+  }
+  throw new Error("unsupported Codex prompt input element");
+}
+
+function accessibleText(node) { return normalizeText(node.getAttribute("aria-label") || node.innerText || node.textContent || ""); }
+function normalizeText(value) { return String(value ?? "").replace(/\r\n?/g, "\n").trim(); }
+function isVisible(node) { const style = getComputedStyle(node); const rect = node.getBoundingClientRect(); return style.display !== "none" && style.visibility !== "hidden" && rect.width > 0 && rect.height > 0; }
+function requireCodexPage() { if (!location.pathname.startsWith("/codex")) throw new Error("active ChatGPT tab is not a Codex page"); }

--- a/extension/dashboard.css
+++ b/extension/dashboard.css
@@ -1,0 +1,25 @@
+:root { color-scheme: light dark; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; background: Canvas; color: CanvasText; }
+button, input, textarea, select { font: inherit; border: 1px solid color-mix(in srgb, CanvasText 22%, transparent); border-radius: 12px; }
+button { min-height: 44px; padding: .7rem 1rem; cursor: pointer; background: color-mix(in srgb, Canvas 88%, CanvasText 12%); color: CanvasText; }
+button:hover { background: color-mix(in srgb, Canvas 82%, CanvasText 18%); }
+button:disabled { opacity: .55; cursor: wait; }
+button.primary { font-weight: 700; }
+input, textarea, select { width: 100%; padding: .72rem .8rem; background: Canvas; color: CanvasText; }
+textarea { resize: vertical; }
+label { display: grid; gap: .45rem; font-weight: 650; }
+.shell { width: min(1080px, 100%); margin: 0 auto; padding: clamp(1rem, 3vw, 2rem); display: grid; gap: 1.25rem; }
+.hero { display: flex; gap: 1rem; align-items: end; justify-content: space-between; }
+h1 { margin: 0; font-size: clamp(2rem, 5vw, 3.5rem); letter-spacing: -.045em; }
+.eyebrow { margin: 0 0 .35rem; text-transform: uppercase; letter-spacing: .14em; font-size: .72rem; opacity: .68; }
+#status { max-width: 40rem; padding: .65rem .8rem; border-radius: 12px; background: color-mix(in srgb, Canvas 92%, CanvasText 8%); }
+#status[data-error="true"] { outline: 2px solid currentColor; }
+.surfaces, .actions { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: .75rem; }
+.surfaces { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; padding: 1rem; border: 1px solid color-mix(in srgb, CanvasText 16%, transparent); border-radius: 18px; }
+.wide { grid-column: 1 / -1; }
+.prompt { display: grid; gap: .5rem; }
+@media (max-width: 700px) { .shell { padding: 1rem; } .hero { align-items: start; flex-direction: column; } #status { width: 100%; } .grid { grid-template-columns: 1fr; } .wide { grid-column: auto; } .surfaces, .actions { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 430px) { .surfaces, .actions { grid-template-columns: 1fr; } button { min-height: 48px; } }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { scroll-behavior: auto !important; transition: none !important; animation: none !important; } }

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Crossdock</title>
+  <link rel="stylesheet" href="dashboard.css">
+</head>
+<body>
+  <main class="shell">
+    <header class="hero">
+      <div><p class="eyebrow">Developer handoff</p><h1>Crossdock</h1></div>
+      <output id="status" role="status" aria-live="polite">Ready.</output>
+    </header>
+
+    <nav class="surfaces" aria-label="Connected work surfaces">
+      <button id="open-chatgpt">ChatGPT</button>
+      <button id="open-codex">Codex</button>
+      <button id="open-github">GitHub</button>
+    </nav>
+
+    <section class="grid" aria-label="Task setup">
+      <label>Target repository <input id="repository" placeholder="owner/repo" autocomplete="off"></label>
+      <label>Issue <input id="issue" inputmode="numeric" placeholder="optional"></label>
+      <label>Existing PR <input id="pull-request" inputmode="numeric" placeholder="blank for a new PR"></label>
+      <label>Handoff mode
+        <select id="handoff-mode"><option value="review">Review before handoff</option><option value="automatic">Automatic</option></select>
+      </label>
+      <label class="wide">Task-record repository <input id="storage-repository" placeholder="private owner/repo" autocomplete="off"></label>
+      <label>Task-record branch <input id="storage-branch" value="main" autocomplete="off"></label>
+      <label class="wide">PR / update summary <textarea id="summary" rows="3" placeholder="What changed and why?"></textarea></label>
+      <label class="wide">Validation <textarea id="validation" rows="3" placeholder="One result per line"></textarea></label>
+    </section>
+
+    <section class="actions" aria-label="Task actions">
+      <button id="capture">Capture prompt</button>
+      <button id="submit" class="primary">Create Codex task</button>
+      <button id="finalize-initial">Finalize new PR</button>
+      <button id="finalize-update">Finalize branch update</button>
+    </section>
+
+    <label class="prompt">Captured prompt <textarea id="prompt" rows="10" readonly></textarea></label>
+  </main>
+  <script src="dashboard.js"></script>
+</body>
+</html>

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -1,0 +1,208 @@
+const $ = (id) => document.getElementById(id);
+const fields = ["repository", "issue", "pull-request", "handoff-mode", "storage-repository", "storage-branch", "summary", "validation", "prompt"];
+const POLL_MS = 5000;
+let taskState = null;
+let monitoring = false;
+
+void restore();
+
+$("open-chatgpt").addEventListener("click", () => send({ type: "crossdock.openChatGPT" }));
+$("open-codex").addEventListener("click", () => send({ type: "crossdock.openCodex" }));
+$("open-github").addEventListener("click", async () => {
+  const repo = requireRepository();
+  const pr = parseOptionalPrNumber();
+  await send({ type: "crossdock.openGitHub", url: pr ? `https://github.com/${repo}/pull/${pr}` : `https://github.com/${repo}` });
+});
+
+$("capture").addEventListener("click", run(async () => {
+  const result = await send({ type: "crossdock.capturePrompt" });
+  $("prompt").value = result.prompt;
+  await persist();
+  setStatus("Captured the latest ChatGPT assistant response.");
+}));
+
+$("submit").addEventListener("click", run(async () => {
+  if (taskState) throw new Error("a coding-agent task is already active");
+  const prompt = $("prompt").value;
+  if (!prompt.trim()) throw new Error("capture a prompt first");
+  const repository = requireRepository();
+  const storage = requireStorage();
+  const prNumber = parseOptionalPrNumber();
+  const mode = prNumber ? "update" : "initial";
+  const initialSnapshot = mode === "update" ? await publish("/pr/snapshot", { target_repository: repository, pull_request: prNumber }) : null;
+
+  const pending = {
+    task_id: `crossdock-${crypto.randomUUID()}`,
+    created_at: new Date().toISOString(),
+    prompt,
+    mode,
+    handoff_mode: $("handoff-mode").value,
+    repository,
+    storage,
+    pull_request: prNumber,
+    initial_head_sha: initialSnapshot?.head_sha ?? null,
+    phase: "submitting",
+  };
+  const result = await send({ type: "crossdock.submitCodex", prompt });
+  taskState = { ...pending, task_url: result.taskUrl, phase: "running" };
+  await saveTaskState();
+  setStatus(`Task submitted. Monitoring for ${mode === "initial" ? "Create PR" : "Update branch"} readiness…`);
+  void monitorTask();
+}));
+
+$("finalize-initial").addEventListener("click", run(async () => { requireReady("initial"); await finalizeInitial(); }));
+$("finalize-update").addEventListener("click", run(async () => { requireReady("update"); await finalizeUpdate(); }));
+for (const id of fields.filter((id) => id !== "prompt")) $(id).addEventListener("change", () => void persist());
+
+async function monitorTask() {
+  if (monitoring || !taskState) return;
+  monitoring = true;
+  try {
+    while (taskState) {
+      if (taskState.phase === "branch-update-clicked") { await finishUpdateAfterRemoteChange(); continue; }
+      if (!["running", "ready"].includes(taskState.phase)) return;
+      if (taskState.phase === "ready" && taskState.handoff_mode === "review") return;
+
+      try {
+        const state = await send({ type: "crossdock.inspectCodex" });
+        const ready = taskState.mode === "initial" ? state.createPrAvailable : state.updateBranchAvailable;
+        if (ready) {
+          taskState.phase = "ready";
+          await saveTaskState();
+          if (taskState.handoff_mode === "automatic") {
+            if (taskState.mode === "initial") await finalizeInitial(); else await finalizeUpdate();
+            continue;
+          }
+          setStatus(`Task is ready. Review the task and choose ${taskState.mode === "initial" ? "Finalize new PR" : "Finalize branch update"}.`);
+          return;
+        }
+        setStatus(`Task is still running. Waiting for ${taskState.mode === "initial" ? "Create PR" : "Update branch"}…`);
+      } catch (error) {
+        setStatus(`Monitoring: ${error.message}. Will retry.`, true);
+      }
+      await sleep(POLL_MS);
+    }
+  } finally { monitoring = false; }
+}
+
+async function finalizeInitial() {
+  requireTaskState("initial");
+  if (!["running", "ready"].includes(taskState.phase)) throw new Error(`initial task cannot finalize from phase ${taskState.phase}`);
+  taskState.phase = "finalizing"; await saveTaskState(); setStatus("Creating PR and recording task provenance…");
+  try {
+    const result = await send({ type: "crossdock.createPrAndInspect", targetRepository: taskState.repository });
+    const prNumber = parsePrNumber(result.prUrl, taskState.repository);
+    $("pull-request").value = String(prNumber);
+    await publish("/handoff/initial", { storage: taskState.storage, task: buildTask({ repository: taskState.repository, prNumber, result }), pr: buildDescription() });
+    await completeTask(prNumber); await persist(); setStatus(`Initial PR finalized: ${result.prUrl}`);
+  } catch (error) { taskState.phase = "ready"; await saveTaskState(); throw error; }
+}
+
+async function finalizeUpdate() {
+  requireTaskState("update");
+  if (!["running", "ready"].includes(taskState.phase)) throw new Error(`update task cannot finalize from phase ${taskState.phase}`);
+  taskState.phase = "finalizing"; await saveTaskState(); setStatus("Updating the PR branch and verifying the remote head…");
+  try {
+    const result = await send({ type: "crossdock.applyBranchUpdate" });
+    taskState.phase = "branch-update-clicked";
+    taskState.final_task_url = result.taskUrl;
+    taskState.final_report = result.report;
+    await saveTaskState();
+    await finishUpdateAfterRemoteChange();
+  } catch (error) {
+    if (taskState?.phase === "finalizing") { taskState.phase = "ready"; await saveTaskState(); }
+    throw error;
+  }
+}
+
+async function finishUpdateAfterRemoteChange() {
+  requireTaskState("update");
+  if (taskState.phase !== "branch-update-clicked") return;
+  const changed = await waitForPrHeadChange({ repository: taskState.repository, prNumber: taskState.pull_request, previousSha: taskState.initial_head_sha });
+  const stored = await chrome.storage.local.get("parentTaskId");
+  const result = { taskUrl: taskState.final_task_url, report: taskState.final_report };
+  await publish("/handoff/update", {
+    storage: taskState.storage,
+    task: { ...buildTask({ repository: taskState.repository, prNumber: taskState.pull_request, result }), parent_task_id: stored.parentTaskId ?? null },
+    update: buildDescription(),
+  });
+  const prNumber = taskState.pull_request;
+  await completeTask(prNumber);
+  setStatus(`Branch update recorded on PR #${prNumber} at ${changed.head_sha.slice(0, 12)}.`);
+}
+
+async function waitForPrHeadChange({ repository, prNumber, previousSha }) {
+  if (!previousSha) throw new Error("pre-update PR head snapshot is missing");
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    const snapshot = await publish("/pr/snapshot", { target_repository: repository, pull_request: prNumber });
+    if (snapshot.head_sha && snapshot.head_sha !== previousSha) return snapshot;
+    await sleep(2000);
+  }
+  throw new Error("timed out waiting for the GitHub PR head to change after Update branch");
+}
+
+async function completeTask(prNumber) {
+  const completedTaskId = taskState.task_id;
+  taskState = null;
+  await chrome.storage.local.set({ parentTaskId: completedTaskId });
+  await chrome.storage.local.remove("taskState");
+  if (prNumber) $("pull-request").value = String(prNumber);
+}
+
+function buildTask({ repository, prNumber, result }) {
+  const issueText = $("issue").value.trim();
+  return {
+    task_id: taskState.task_id,
+    created_at: taskState.created_at,
+    completed_at: new Date().toISOString(),
+    target_repository: repository,
+    pull_request: prNumber,
+    issue: issueText ? Number(issueText) : null,
+    agent_task_url: result.taskUrl,
+    prompt: taskState.prompt,
+    report: result.report,
+  };
+}
+
+function buildDescription() {
+  return {
+    summary: $("summary").value.trim() || "Completed the delegated task.",
+    validation: $("validation").value.split(/\r?\n/).map((line) => line.trim()).filter(Boolean),
+  };
+}
+
+function requireStorage() {
+  const repository = $("storage-repository").value.trim();
+  const branch = $("storage-branch").value.trim();
+  if (!/^[^/\s]+\/[^/\s]+$/.test(repository)) throw new Error("task-record repository must be configured as owner/repo");
+  if (!branch) throw new Error("task-record branch is required");
+  if (repository === "seedbed-ai/crossdock") throw new Error("the public Crossdock source repository cannot be used as the implicit task-record store");
+  return { repository, branch };
+}
+
+async function publish(path, body) {
+  const response = await fetch(`http://127.0.0.1:3210${path}`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+  const payload = await response.json();
+  if (!response.ok) throw new Error(payload.message ?? payload.error ?? `handoff failed: ${response.status}`);
+  return payload;
+}
+
+async function send(message) {
+  const response = await chrome.runtime.sendMessage(message);
+  if (!response?.ok) throw new Error(response?.error ?? "extension action failed");
+  return response.result;
+}
+
+function requireRepository() { const repository = $("repository").value.trim(); if (!/^[^/\s]+\/[^/\s]+$/.test(repository)) throw new Error("target repository must be owner/repo"); return repository; }
+function parseOptionalPrNumber() { const value = $("pull-request").value.trim(); if (!value) return null; const number = Number(value); if (!Number.isInteger(number) || number <= 0) throw new Error("existing PR must be a positive integer"); return number; }
+function parsePrNumber(url, repository) { const escaped = repository.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); const match = url.match(new RegExp(`github\\.com/${escaped}/pull/(\\d+)`)); if (!match) throw new Error("coding agent did not expose a PR URL for the target repository"); return Number(match[1]); }
+function requireTaskState(mode) { if (!taskState?.task_id || !taskState.prompt) throw new Error("no submitted task is active"); if (mode && taskState.mode !== mode) throw new Error(`active task is ${taskState.mode}, not ${mode}`); }
+function requireReady(mode) { requireTaskState(mode); if (taskState.phase !== "ready") throw new Error("task is not ready for handoff yet"); }
+function run(fn) { return async () => { setBusy(true); try { await fn(); } catch (error) { setStatus(error.message, true); } finally { setBusy(false); } }; }
+function setBusy(value) { for (const button of document.querySelectorAll("button")) button.disabled = value; }
+function setStatus(message, error = false) { $("status").textContent = message; $("status").dataset.error = error ? "true" : "false"; }
+async function saveTaskState() { await chrome.storage.local.set({ taskState }); }
+async function persist() { const values = Object.fromEntries(fields.map((id) => [id, $(id).value])); await chrome.storage.local.set({ dashboard: values }); }
+async function restore() { const stored = await chrome.storage.local.get(["dashboard", "taskState"]); for (const [id, value] of Object.entries(stored.dashboard ?? {})) if ($(id)) $(id).value = value; taskState = stored.taskState ?? null; if (taskState) { setStatus(`Recovered active ${taskState.mode} task in phase ${taskState.phase}.`); if (taskState.phase !== "ready" || taskState.handoff_mode === "automatic") void monitorTask(); } }
+function sleep(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": 3,
+  "name": "Crossdock",
+  "version": "0.1.0",
+  "description": "Orchestrates conversation to coding-agent to GitHub handoffs.",
+  "permissions": ["tabs", "storage"],
+  "host_permissions": ["https://chatgpt.com/*", "http://127.0.0.1:3210/*"],
+  "background": { "service_worker": "background.js", "type": "module" },
+  "action": { "default_title": "Open Crossdock" },
+  "content_scripts": [
+    { "matches": ["https://chatgpt.com/*"], "js": ["content.js"], "run_at": "document_idle" }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "node": ">=22"
   },
   "scripts": {
+    "start": "node server.js",
     "test": "node --test",
-    "check": "node --check src/github-client.js && node --check src/handoff.js && node --check src/index.js && node --check src/task-log.js && node --check tests/github-client.test.js && node --check tests/handoff.test.js && node --check tests/task-log.test.js"
+    "check": "node --check server.js && node --check src/github-client.js && node --check src/handoff.js && node --check src/http-server.js && node --check src/index.js && node --check src/service.js && node --check src/task-log.js && node --check extension/background.js && node --check extension/content.js && node --check extension/dashboard.js && node --check tests/github-client.test.js && node --check tests/handoff.test.js && node --check tests/http-server.test.js && node --check tests/service.test.js && node --check tests/task-log.test.js"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,16 @@
+import { GitHubClient } from "./src/github-client.js";
+import { createHandoffServer } from "./src/http-server.js";
+
+const token = process.env.GITHUB_TOKEN;
+if (!token) {
+  console.error("GITHUB_TOKEN is required");
+  process.exit(1);
+}
+
+const port = Number(process.env.PORT ?? 3210);
+const github = new GitHubClient({ token });
+const server = createHandoffServer({ github });
+
+server.listen(port, "127.0.0.1", () => {
+  console.log(`Crossdock service listening on http://127.0.0.1:${port}`);
+});

--- a/src/handoff.js
+++ b/src/handoff.js
@@ -22,13 +22,37 @@ export async function publishInitialHandoff({ github, storage, task, pr }) {
   const destination = requireStorage(storage);
   validateTaskRecord({ ...task, task_type: "initial", pull_request: null, parent_task_id: null });
   const createdPr = await github.createPullRequest(task.target_repository, {
-    title: pr.title, body: pr.provisionalBody ?? pr.summary, head: task.working_branch, base: task.base_branch, draft: pr.draft ?? false,
+    title: pr.title,
+    body: pr.provisionalBody ?? pr.summary,
+    head: task.working_branch,
+    base: task.base_branch,
+    draft: pr.draft ?? false,
   });
-  const record = { ...task, task_type: "initial", pull_request: createdPr.number, parent_task_id: null };
+  return publishExistingInitialHandoff({
+    github,
+    storage: destination,
+    task: { ...task, pull_request: createdPr.number },
+    pr,
+  });
+}
+
+export async function publishExistingInitialHandoff({ github, storage, task, pr }) {
+  const destination = requireStorage(storage);
+  const record = { ...task, task_type: "initial", parent_task_id: null };
+  validateTaskRecord(record);
+  if (!record.pull_request) throw new Error("existing initial handoff requires pull_request");
+
   const persisted = await persistTaskLog({ github, storage: destination, record });
-  const body = buildPrBody({ summary: pr.summary, validation: pr.validation, issue: task.issue, logUrl: persisted.url, branch: task.working_branch, commit: task.result_commit });
-  await github.updatePullRequest(task.target_repository, createdPr.number, { body });
-  const verified = await github.getPullRequest(task.target_repository, createdPr.number);
+  const body = buildPrBody({
+    summary: pr.summary,
+    validation: pr.validation,
+    issue: task.issue,
+    logUrl: persisted.url,
+    branch: task.working_branch,
+    commit: task.result_commit,
+  });
+  await github.updatePullRequest(task.target_repository, record.pull_request, { body });
+  const verified = await github.getPullRequest(task.target_repository, record.pull_request);
   if (!verified.body?.includes(persisted.url)) throw new Error("initial handoff verification failed: PR body does not link task record");
   await verifyTaskLog({ github, storage: destination, path: persisted.path, ref: persisted.commitSha, expectedContent: persisted.content });
   return { pullRequest: verified, taskLog: persisted };

--- a/src/http-server.js
+++ b/src/http-server.js
@@ -1,0 +1,61 @@
+import { createServer } from "node:http";
+import { dispatchHandoff } from "./service.js";
+
+export function createHandoffServer({ github, maxBodyBytes = 4 * 1024 * 1024 }) {
+  return createServer(async (request, response) => {
+    try {
+      assertAllowedOrigin(request, response);
+      if (request.method === "OPTIONS") {
+        response.writeHead(204);
+        response.end();
+        return;
+      }
+      if (request.method === "POST" && !String(request.headers["content-type"] ?? "").startsWith("application/json")) {
+        sendJson(response, 415, { error: "application_json_required" });
+        return;
+      }
+      const body = await readJson(request, maxBodyBytes);
+      const result = await dispatchHandoff({ method: request.method, path: new URL(request.url, "http://127.0.0.1").pathname, body, github });
+      sendJson(response, result.status, result.body);
+    } catch (error) {
+      const status = Number.isInteger(error.status) && error.status >= 400 ? error.status : 500;
+      sendJson(response, status, { error: "handoff_failed", message: error.message, github: error.payload ?? undefined });
+    }
+  });
+}
+
+export function assertAllowedOrigin(request, response) {
+  const origin = request.headers.origin;
+  if (!origin) return;
+  if (!origin.startsWith("chrome-extension://")) {
+    const error = new Error("browser origin is not authorized for the local Crossdock service");
+    error.status = 403;
+    throw error;
+  }
+  response.setHeader("Access-Control-Allow-Origin", origin);
+  response.setHeader("Vary", "Origin");
+  response.setHeader("Access-Control-Allow-Headers", "Content-Type");
+  response.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+}
+
+async function readJson(request, maxBodyBytes) {
+  if (request.method === "GET" || request.method === "HEAD") return null;
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of request) {
+    size += chunk.length;
+    if (size > maxBodyBytes) {
+      const error = new Error(`request body exceeds ${maxBodyBytes} byte limit`);
+      error.status = 413;
+      throw error;
+    }
+    chunks.push(chunk);
+  }
+  if (!chunks.length) return null;
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+function sendJson(response, status, body) {
+  response.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+  response.end(JSON.stringify(body));
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
 export { GitHubClient } from "./github-client.js";
-export { buildPrBody, buildUpdateComment, persistTaskLog, publishInitialHandoff, publishUpdateHandoff } from "./handoff.js";
+export { buildPrBody, buildUpdateComment, persistTaskLog, publishExistingInitialHandoff, publishInitialHandoff, publishUpdateHandoff } from "./handoff.js";
 export { TASK_LOG_SCHEMA, assertGithubSafe, canonicalizeText, renderTaskLog, sha256, taskLogPath, validateTaskRecord } from "./task-log.js";
+export { createHandoffServer } from "./http-server.js";
+export { dispatchHandoff, hydrateTaskFromPullRequest } from "./service.js";

--- a/src/service.js
+++ b/src/service.js
@@ -1,0 +1,61 @@
+import { publishInitialHandoff, publishUpdateHandoff } from "./handoff.js";
+
+export async function dispatchHandoff({ method, path, body, github }) {
+  if (method === "GET" && path === "/health") return { status: 200, body: { ok: true } };
+  if (method !== "POST") return { status: 405, body: { error: "method_not_allowed" } };
+
+  if (path === "/pr/snapshot") {
+    requireObject(body, "body");
+    const task = await hydrateTaskFromPullRequest(github, {
+      target_repository: body.target_repository,
+      pull_request: body.pull_request,
+    });
+    return {
+      status: 200,
+      body: {
+        repository: task.target_repository,
+        pull_request: task.pull_request,
+        base_branch: task.base_branch,
+        working_branch: task.working_branch,
+        head_sha: task.result_commit,
+      },
+    };
+  }
+
+  if (path === "/handoff/initial" || path === "/handoff/update") {
+    requireObject(body, "body");
+    requireObject(body.task, "task");
+    requireObject(body.storage, "storage");
+    const task = await hydrateTaskFromPullRequest(github, body.task);
+
+    if (path === "/handoff/initial") {
+      const result = await publishInitialHandoff({ github, storage: body.storage, task, pr: body.pr });
+      return { status: 200, body: summarizeInitial(result) };
+    }
+
+    const result = await publishUpdateHandoff({ github, storage: body.storage, task, update: body.update });
+    return { status: 200, body: summarizeUpdate(result) };
+  }
+
+  return { status: 404, body: { error: "not_found" } };
+}
+
+export async function hydrateTaskFromPullRequest(github, task) {
+  if (typeof task.target_repository !== "string" || !/^[^/]+\/[^/]+$/.test(task.target_repository)) throw new Error("target_repository is required in owner/repo form");
+  if (!Number.isInteger(task.pull_request) || task.pull_request <= 0) throw new Error("pull_request is required");
+  const pr = await github.getPullRequest(task.target_repository, task.pull_request);
+  if (!pr?.base?.ref || !pr?.head?.ref || !pr?.head?.sha) throw new Error("target PR is missing base/head metadata");
+  return { ...task, base_branch: pr.base.ref, working_branch: pr.head.ref, result_commit: pr.head.sha };
+}
+
+function summarizeInitial(result) {
+  return { pull_request: result.pullRequest.number, pull_request_url: result.pullRequest.html_url ?? result.pullRequest.url ?? null, task_record_url: result.taskLog.url };
+}
+
+function summarizeUpdate(result) {
+  return { comment_id: result.comment.id, comment_url: result.comment.html_url ?? result.comment.url ?? null, task_record_url: result.taskLog.url };
+}
+
+function requireObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new TypeError(`${label} must be an object`);
+}

--- a/src/service.js
+++ b/src/service.js
@@ -1,4 +1,4 @@
-import { publishInitialHandoff, publishUpdateHandoff } from "./handoff.js";
+import { publishExistingInitialHandoff, publishUpdateHandoff } from "./handoff.js";
 
 export async function dispatchHandoff({ method, path, body, github }) {
   if (method === "GET" && path === "/health") return { status: 200, body: { ok: true } };
@@ -10,16 +10,7 @@ export async function dispatchHandoff({ method, path, body, github }) {
       target_repository: body.target_repository,
       pull_request: body.pull_request,
     });
-    return {
-      status: 200,
-      body: {
-        repository: task.target_repository,
-        pull_request: task.pull_request,
-        base_branch: task.base_branch,
-        working_branch: task.working_branch,
-        head_sha: task.result_commit,
-      },
-    };
+    return { status: 200, body: { repository: task.target_repository, pull_request: task.pull_request, base_branch: task.base_branch, working_branch: task.working_branch, head_sha: task.result_commit } };
   }
 
   if (path === "/handoff/initial" || path === "/handoff/update") {
@@ -29,7 +20,7 @@ export async function dispatchHandoff({ method, path, body, github }) {
     const task = await hydrateTaskFromPullRequest(github, body.task);
 
     if (path === "/handoff/initial") {
-      const result = await publishInitialHandoff({ github, storage: body.storage, task, pr: body.pr });
+      const result = await publishExistingInitialHandoff({ github, storage: body.storage, task, pr: body.pr });
       return { status: 200, body: summarizeInitial(result) };
     }
 

--- a/tests/http-server.test.js
+++ b/tests/http-server.test.js
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { createHandoffServer } from "../src/http-server.js";
+
+function githubMock() { return { async getPullRequest() { throw new Error("not expected"); } }; }
+
+async function withServer(fn, options = {}) {
+  const server = createHandoffServer({ github: githubMock(), ...options });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try { await fn(server.address().port); } finally { await new Promise((resolve) => server.close(resolve)); }
+}
+
+function request(port, { method = "GET", path = "/health", origin, contentType, body } = {}) {
+  return new Promise((resolve, reject) => {
+    const headers = {};
+    if (origin) headers.Origin = origin;
+    if (contentType) headers["Content-Type"] = contentType;
+    const req = http.request({ hostname: "127.0.0.1", port, method, path, headers }, (res) => {
+      const chunks = [];
+      res.on("data", (chunk) => chunks.push(chunk));
+      res.on("end", () => resolve({ status: res.statusCode, headers: res.headers, body: JSON.parse(Buffer.concat(chunks).toString("utf8") || "null") }));
+    });
+    req.on("error", reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+test("health permits non-browser local clients", async () => {
+  await withServer(async (port) => {
+    const result = await request(port);
+    assert.equal(result.status, 200);
+    assert.equal(result.body.ok, true);
+  });
+});
+
+test("browser requests reject arbitrary web origins", async () => {
+  await withServer(async (port) => {
+    const result = await request(port, { origin: "https://example.com" });
+    assert.equal(result.status, 403);
+  });
+});
+
+test("extension origin receives scoped CORS response", async () => {
+  await withServer(async (port) => {
+    const origin = "chrome-extension://abcdefghijklmnop";
+    const result = await request(port, { origin });
+    assert.equal(result.status, 200);
+    assert.equal(result.headers["access-control-allow-origin"], origin);
+  });
+});
+
+test("POST requires JSON content type", async () => {
+  await withServer(async (port) => {
+    const result = await request(port, { method: "POST", path: "/pr/snapshot", origin: "chrome-extension://abcdefghijklmnop", contentType: "text/plain", body: "{}" });
+    assert.equal(result.status, 415);
+  });
+});
+
+test("request bodies are bounded", async () => {
+  await withServer(async (port) => {
+    const result = await request(port, { method: "POST", path: "/pr/snapshot", origin: "chrome-extension://abcdefghijklmnop", contentType: "application/json", body: JSON.stringify({ text: "x".repeat(100) }) });
+    assert.equal(result.status, 413);
+  }, { maxBodyBytes: 20 });
+});

--- a/tests/service.test.js
+++ b/tests/service.test.js
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { dispatchHandoff, hydrateTaskFromPullRequest } from "../src/service.js";
+
+function githubMock() {
+  let body = "provisional";
+  let storedContent = "";
+  return {
+    calls: [],
+    async getPullRequest(repository, number) {
+      this.calls.push(["getPullRequest", repository, number]);
+      return { number, body, html_url: `https://github.com/${repository}/pull/${number}`, base: { ref: "main" }, head: { ref: "crossdock/task", sha: "0123456789abcdef0123456789abcdef01234567" } };
+    },
+    async createFile(repository, path, content) {
+      this.calls.push(["createFile", repository, path]); storedContent = content; return { commit: { sha: "abc123" } };
+    },
+    async updatePullRequest(repository, number, payload) {
+      this.calls.push(["updatePullRequest", repository, number]); body = payload.body; return { number, body };
+    },
+    async getFile(repository, path, ref) {
+      this.calls.push(["getFile", repository, path, ref]); return { sha: "blob", content: Buffer.from(storedContent).toString("base64") };
+    },
+    async addIssueComment() { throw new Error("not expected"); },
+    async getIssueComments() { return []; },
+  };
+}
+
+const task = {
+  task_id: "task-001",
+  created_at: "2026-08-31T20:00:00Z",
+  completed_at: "2026-08-31T20:05:00Z",
+  target_repository: "example/project",
+  pull_request: 9,
+  prompt: "Do the task.",
+  report: "Done.",
+  agent_task_url: "https://example.invalid/task/1",
+};
+
+const storage = { repository: "example/private-records", branch: "main" };
+
+test("hydrateTaskFromPullRequest trusts remote PR refs and head SHA", async () => {
+  const github = githubMock();
+  const hydrated = await hydrateTaskFromPullRequest(github, task);
+  assert.equal(hydrated.base_branch, "main");
+  assert.equal(hydrated.working_branch, "crossdock/task");
+  assert.equal(hydrated.result_commit, "0123456789abcdef0123456789abcdef01234567");
+});
+
+test("initial service enriches existing PR instead of creating another", async () => {
+  const github = githubMock();
+  const result = await dispatchHandoff({
+    method: "POST",
+    path: "/handoff/initial",
+    github,
+    body: { task, storage, pr: { summary: "Implemented.", validation: ["tests passed"] } },
+  });
+  assert.equal(result.status, 200);
+  assert.ok(github.calls.some(([name]) => name === "updatePullRequest"));
+  assert.ok(!github.calls.some(([name]) => name === "createPullRequest"));
+  assert.match(result.body.task_record_url, /example\/private-records/);
+});
+
+test("handoff endpoints require explicit storage", async () => {
+  const github = githubMock();
+  await assert.rejects(
+    dispatchHandoff({ method: "POST", path: "/handoff/initial", github, body: { task, pr: { summary: "Implemented." } } }),
+    /storage must be an object/,
+  );
+});


### PR DESCRIPTION
## Summary

- migrates the public-safe browser/Codex adapter and loopback Node handoff service from private incubation
- renames Seedbed-specific extension/message identity to Crossdock
- makes task-record storage explicit in the dashboard/service instead of defaulting to `seedbed-ai/dev-tools`
- adds review-before-handoff and automatic handoff modes
- adds a responsive dashboard layout suitable for desktop widths and narrow/mobile-sized viewports
- preserves fail-closed tab/control resolution, branch-update head-change verification, and extension-origin-only browser access to the loopback mutation service
- fixes the initial flow so the service enriches the PR already created by Codex rather than creating a duplicate PR
- adds CI plus service/HTTP boundary tests

## Validation

GitHub Actions runs `npm test` and `npm run check` on Node 22. The local runner in this environment cannot resolve external DNS, so the PR CI is the executable validation authority for the exact remote branch.

## Privacy / security

- no private task logs or Seedbed-private configuration were migrated
- public `seedbed-ai/crossdock` is rejected by the dashboard as the task-record destination
- browser-origin access to the local service is restricted to `chrome-extension://` origins
- the extension does not extract browser session cookies or credentials

Closes #5