### PR TITLE
feat: make task evidence retention configurable

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,9 @@ Crossdock is in early public development. These documents describe the intended 
 ## Start here
 
 - [`getting-started.md`](getting-started.md) — current development setup and project status.
+- [`testing/public-live-test.md`](testing/public-live-test.md) — provider-neutral desktop live-test steps for public testers.
 - [`concepts/workflow.md`](concepts/workflow.md) — task lifecycle from prompt through PR handoff.
-- [`concepts/task-records.md`](concepts/task-records.md) — durable prompt/report provenance.
+- [`concepts/task-records.md`](concepts/task-records.md) — durable task metadata and configurable evidence retention.
 - [`concepts/adapters.md`](concepts/adapters.md) — provider boundary model.
 - [`configuration/handoff-mode.md`](configuration/handoff-mode.md) — automatic vs review-before-handoff direction.
 - [`configuration/task-log-storage.md`](configuration/task-log-storage.md) — storage privacy and configuration.

--- a/docs/concepts/task-records.md
+++ b/docs/concepts/task-records.md
@@ -1,11 +1,17 @@
 # Task Records
 
-A completed Crossdock execution has one immutable task record containing the exact canonical delegated prompt, complete final execution report, stable task metadata, and integrity digests.
+A completed Crossdock execution has one immutable task record containing stable handoff metadata and whatever prompt/report evidence the user or deployment explicitly selected.
 
-The record is execution provenance, not merge authority. It allows a reviewer or later automation to reconstruct what was delegated and what the coding agent reported without stuffing the complete transcript into every PR body.
+Task records are execution provenance, not merge authority. They provide a durable index of what Crossdock did without forcing every user to retain the same amount of private task content.
+
+Prompt and report evidence are independent choices. A user may retain complete plaintext, retain only a hash, or omit that evidence class entirely. The record must state the effective policy truthfully so absence is never mistaken for evidence that exists elsewhere.
+
+Crossdock should favor user control and data minimization. Defaults are convenience, not a reason to lock users into a retention policy. Future schema/configuration work may add encrypted, external-reference, redacted/transformed, local-only, expiring, or other evidence modes where their meaning can be represented unambiguously.
 
 Task records may contain private development context. Their storage location is therefore explicit configuration. The public Crossdock source repository is never an implicit task-record destination.
 
 Initial tasks link the record from the PR body. Subsequent executions on the same PR branch receive distinct records and distinct top-level PR comments so earlier provenance is not overwritten.
+
+Durable task-record retention is separate from transient collection and crash-recovery state. A user who omits durable evidence may still care whether Crossdock temporarily holds that content locally; that lifecycle is tracked as an independent privacy/control concern.
 
 See the implementation-level schema in [`../reference/task-record-schema.md`](../reference/task-record-schema.md).

--- a/docs/reference/task-record-schema.md
+++ b/docs/reference/task-record-schema.md
@@ -1,8 +1,8 @@
 # Crossdock Task Record Schema
 
-Schema identifier: `crossdock.task-record/v1`
+Schema identifier: `crossdock.task-record/v2`
 
-A task record is an immutable Markdown record of one completed coding-agent execution.
+A task record is an immutable Markdown record of one completed coding-agent execution. It always preserves stable handoff metadata. Prompt and report evidence are independently configurable.
 
 ## Path
 
@@ -12,9 +12,23 @@ crossdock/tasks/<target-owner>/<target-repo>/<yyyy>/<mm>/<task-id>.md
 
 Existing records must not be overwritten. Corrections or follow-up executions create new task records.
 
+## Evidence policy
+
+Each evidence class currently supports three modes:
+
+- `full` — persist the complete canonical plaintext and its SHA-256 digest;
+- `hash` — persist only the SHA-256 digest, not plaintext;
+- `omit` — persist neither plaintext nor digest.
+
+Prompt and report modes are independent, so the schema supports full evidence, prompt-only, report-only, metadata-only, and mixed hash/plaintext profiles.
+
+If `evidence_policy` is absent at the API boundary, Crossdock currently resolves it to `full` for both fields for compatibility. User-facing clients should expose the effective policy before durable persistence rather than relying on an invisible default.
+
+The schema is intentionally extensible for future explicit modes such as encrypted, external-reference, redacted/transformed, local-only, or expiring evidence. Those modes must not claim plaintext was retained when it was not.
+
 ## Structure
 
-Each record uses YAML front matter followed by the exact canonical prompt and complete execution report. Current fields are:
+Each record uses YAML front matter followed only by plaintext evidence selected as `full`. Current fields are:
 
 - `schema`
 - `task_id`
@@ -30,18 +44,29 @@ Each record uses YAML front matter followed by the exact canonical prompt and co
 - `agent_task_url`
 - `result_commit`
 - `parent_task_id`
+- `prompt_evidence`
+- `report_evidence`
 - `prompt_sha256`
 - `report_sha256`
 
+`prompt_sha256` or `report_sha256` is `null` when that evidence class uses `omit`. A hash-only record contains the digest but no corresponding Markdown plaintext section.
+
 ## Invariants
 
-1. Prompt and report text is canonicalized to UTF-8/LF semantics before hashing/rendering.
-2. `prompt_sha256` and `report_sha256` are SHA-256 digests of their canonical text.
-3. Initial tasks have no parent task.
-4. Update tasks identify a pull request and should identify their preceding related task when known.
-5. Known secret-like material must fail closed before GitHub-backed persistence.
-6. Storage is explicitly configured and must be appropriate for the data's confidentiality.
-7. Initial task records are linked from the PR body; later update records are linked from new top-level PR comments rather than rewriting earlier provenance.
-8. Durable task record and PR linkage are remotely re-read before a handoff is reported complete.
+1. Retained or hashed text is canonicalized to UTF-8/LF semantics before hashing.
+2. `full` preserves complete canonical plaintext and its SHA-256 digest.
+3. `hash` preserves a digest without plaintext and must not be represented as equivalent to retained plaintext evidence.
+4. `omit` preserves neither plaintext nor digest and is represented explicitly in metadata.
+5. Secret-like content fails closed when a GitHub-backed record would persist it as plaintext. Omitted/hash-only content is not copied into the record.
+6. Initial tasks have no parent task.
+7. Update tasks identify a pull request and should identify their preceding related task when known.
+8. Storage is explicitly configured and must be appropriate for the confidentiality of the evidence actually retained.
+9. Initial task records are linked from the PR body; later update records are linked from new top-level PR comments rather than rewriting earlier provenance.
+10. Durable task record and PR linkage are remotely re-read before a handoff is reported complete.
+11. Crossdock must not silently broaden evidence retention beyond the effective selected policy.
 
-Readers should reject unknown major schema versions unless they explicitly support them. Additive compatible metadata may be introduced later without weakening these invariants.
+## Versioning
+
+Version 1 required full prompt and full report evidence. Version 2 adds explicit independent evidence policy and optional prompt/report content.
+
+Readers should reject unknown major schema versions unless they explicitly support them. Additive compatible metadata may be introduced later without weakening truthful provenance, classification, immutability, or linkage semantics.

--- a/docs/testing/public-live-test.md
+++ b/docs/testing/public-live-test.md
@@ -1,0 +1,138 @@
+# Public Live Test Guide
+
+Crossdock is in early development. This guide is for public testers validating the current desktop browser adapter and local handoff service. It does not require or assume access to any project-private repository or infrastructure.
+
+## Current platform boundary
+
+The current live test requires a desktop Chromium-compatible browser that can load an unpacked Manifest V3 extension and a local Node.js 22+ process.
+
+Mobile browsers are not currently supported for this adapter. Do not treat a responsive dashboard as proof of mobile support: the present localhost + browser-extension integration mechanism is desktop-only.
+
+## 1. Prepare two repositories
+
+Use:
+
+- a disposable target repository where the coding agent may create or update a pull request; and
+- a private task-record repository that is appropriate for any prompt/report evidence you choose to retain.
+
+Do not use the public Crossdock source repository as an implicit task-record destination.
+
+## 2. Get Crossdock
+
+Clone the public Crossdock repository and enter it:
+
+```sh
+git clone https://github.com/seedbed-ai/crossdock.git
+cd crossdock
+```
+
+Use Node.js 22 or newer, then verify the checkout:
+
+```sh
+node --version
+npm test
+npm run check
+```
+
+Stop and report the non-secret output if either validation command fails.
+
+## 3. Configure GitHub access locally
+
+Provide a GitHub credential to the local Crossdock service with only the repository access needed for the test. The service currently reads `GITHUB_TOKEN`.
+
+Do not paste credentials into issues, task records, screenshots, chat transcripts, or the Crossdock repository.
+
+Start the local service:
+
+```sh
+npm start
+```
+
+Leave it running during the test. It binds to loopback rather than a public network interface.
+
+## 4. Load the extension
+
+In a desktop Chromium-compatible browser:
+
+1. open the browser's extensions management page;
+2. enable developer mode;
+3. choose the option to load an unpacked extension;
+4. select this checkout's `extension/` directory;
+5. open the Crossdock dashboard.
+
+Authenticate normally to the conversation, coding-agent, and GitHub services you intend to test. Crossdock must not require extraction of browser cookies or session credentials.
+
+## 5. Configure the dashboard
+
+Set:
+
+- the disposable target repository;
+- the private task-record repository and branch;
+- `Review before handoff` for the first run;
+- the prompt evidence policy;
+- the report evidence policy.
+
+Prompt and report evidence are independent. Current options are:
+
+- **full** — store canonical plaintext plus a SHA-256 digest;
+- **hash** — store the digest without plaintext;
+- **omit** — store neither plaintext nor digest.
+
+The effective evidence policy applies to the task being submitted and must not silently broaden during handoff.
+
+## 6. Run a minimal initial task
+
+Use a deliberately small, reversible change in the disposable target repository, such as adding one harmless text file.
+
+Capture the intended prompt with Crossdock and submit it to the coding agent. When the task becomes ready, review it before choosing **Finalize new PR**.
+
+Do not manually repair Crossdock if automation fails. A live-test failure is useful compatibility evidence.
+
+Record the exact non-secret failure state instead: dashboard message, visible provider state, target PR state, and a screenshot when useful.
+
+## 7. Verify the initial handoff
+
+A successful initial handoff should produce:
+
+1. exactly one intended pull request;
+2. the expected target branch and change;
+3. a PR body containing the normal review information and a durable link to one immutable task record;
+4. a task record whose evidence fields match the selected prompt/report policy;
+5. no unexpected publication of private prompt/report plaintext.
+
+For `hash`, verify that plaintext is absent and the digest is present. For `omit`, verify that both plaintext and digest are absent while the record explicitly states that the evidence class was omitted.
+
+## 8. Run an update task
+
+Submit a second small task against the existing pull request.
+
+Crossdock should:
+
+1. snapshot the current PR head;
+2. use the coding agent's branch-update action;
+3. wait until GitHub reports a different head SHA;
+4. create a new immutable task record using the selected evidence policy; and
+5. add a new top-level PR comment linking that record.
+
+It must not rewrite the original PR body merely to append later provenance.
+
+## 9. Test automatic mode
+
+After both review-mode flows work, repeat with automatic handoff enabled. The durable result should be equivalent; only the approval transition should differ.
+
+## 10. Failure cases worth reporting
+
+Useful live-test failures include:
+
+- multiple matching conversation or coding-agent tabs;
+- missing or duplicate action buttons;
+- changed semantic selectors;
+- incorrect or incomplete report capture;
+- failure to discover the created PR;
+- stale PR identity or unchanged branch head;
+- invalid/private-storage configuration;
+- localhost service failure;
+- browser restart/task recovery problems;
+- evidence retained despite a `hash` or `omit` policy.
+
+Never include access tokens, cookies, credentials, private task evidence, or other secrets in a public bug report.

--- a/extension/background.js
+++ b/extension/background.js
@@ -31,13 +31,13 @@ async function handleMessage(message) {
       const tab = await findChatGptTab(true);
       const beforeTabs = new Set(await matchingPrTabUrls(message.targetRepository));
       const beforePage = new Set((await sendToTab(tab.id, { type: "crossdock.findPrUrls", targetRepository: message.targetRepository })).prUrls);
-      const prepared = await sendToTab(tab.id, { type: "crossdock.prepareCreatePr" });
+      const prepared = await sendToTab(tab.id, { type: "crossdock.prepareCreatePr", captureReport: message.captureReport !== false });
       const prUrl = await waitForPrUrl({ tabId: tab.id, targetRepository: message.targetRepository, beforeTabs, beforePage });
       return { ...prepared, prUrl };
     }
     case "crossdock.applyBranchUpdate": {
       const tab = await findChatGptTab(true);
-      return sendToTab(tab.id, { type: "crossdock.prepareBranchUpdate" });
+      return sendToTab(tab.id, { type: "crossdock.prepareBranchUpdate", captureReport: message.captureReport !== false });
     }
     case "crossdock.openChatGPT": return activateOrCreate(CHATGPT_URL, false);
     case "crossdock.openCodex": return activateOrCreate(CODEX_URL, true);

--- a/extension/content.js
+++ b/extension/content.js
@@ -11,8 +11,8 @@ async function handleMessage(message) {
     case "crossdock.submitCodex": return submitCodexPrompt(message.prompt);
     case "crossdock.inspectCodex": return inspectCodexTask();
     case "crossdock.findPrUrls": return { prUrls: findPullRequestLinks(message.targetRepository) };
-    case "crossdock.prepareCreatePr": return prepareCreatePr();
-    case "crossdock.prepareBranchUpdate": return prepareBranchUpdate();
+    case "crossdock.prepareCreatePr": return prepareCreatePr(message.captureReport !== false);
+    case "crossdock.prepareBranchUpdate": return prepareBranchUpdate(message.captureReport !== false);
     default: throw new Error(`unsupported content message: ${message.type}`);
   }
 }
@@ -38,16 +38,18 @@ function inspectCodexTask() {
   return { taskUrl: location.href, createPrAvailable: Boolean(findButton(["Create PR"], false)), updateBranchAvailable: Boolean(findButton(["Update branch"], false)) };
 }
 
-function prepareCreatePr() {
+function prepareCreatePr(captureReport = true) {
   requireCodexPage();
-  const result = { taskUrl: location.href, report: captureCodexReport() };
+  const result = { taskUrl: location.href };
+  if (captureReport) result.report = captureCodexReport();
   findButton(["Create PR"], true).click();
   return result;
 }
 
-function prepareBranchUpdate() {
+function prepareBranchUpdate(captureReport = true) {
   requireCodexPage();
-  const result = { taskUrl: location.href, report: captureCodexReport() };
+  const result = { taskUrl: location.href };
+  if (captureReport) result.report = captureCodexReport();
   findButton(["Update branch"], true).click();
   return result;
 }

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -28,6 +28,21 @@
       </label>
       <label class="wide">Task-record repository <input id="storage-repository" placeholder="private owner/repo" autocomplete="off"></label>
       <label>Task-record branch <input id="storage-branch" value="main" autocomplete="off"></label>
+      <label>Prompt evidence
+        <select id="prompt-evidence">
+          <option value="full">Store full prompt</option>
+          <option value="hash">Store hash only</option>
+          <option value="omit">Store no prompt evidence</option>
+        </select>
+      </label>
+      <label>Report evidence
+        <select id="report-evidence">
+          <option value="full">Store full report</option>
+          <option value="hash">Store hash only</option>
+          <option value="omit">Store no report evidence</option>
+        </select>
+      </label>
+      <p class="wide">Evidence settings control durable task records. Hash-only keeps an integrity digest without plaintext. Omit stores neither plaintext nor digest for that evidence class.</p>
       <label class="wide">PR / update summary <textarea id="summary" rows="3" placeholder="What changed and why?"></textarea></label>
       <label class="wide">Validation <textarea id="validation" rows="3" placeholder="One result per line"></textarea></label>
     </section>

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -1,5 +1,5 @@
 const $ = (id) => document.getElementById(id);
-const fields = ["repository", "issue", "pull-request", "handoff-mode", "storage-repository", "storage-branch", "summary", "validation", "prompt"];
+const fields = ["repository", "issue", "pull-request", "handoff-mode", "storage-repository", "storage-branch", "prompt-evidence", "report-evidence", "summary", "validation", "prompt"];
 const POLL_MS = 5000;
 let taskState = null;
 let monitoring = false;
@@ -27,6 +27,7 @@ $("submit").addEventListener("click", run(async () => {
   if (!prompt.trim()) throw new Error("capture a prompt first");
   const repository = requireRepository();
   const storage = requireStorage();
+  const evidencePolicy = readEvidencePolicy();
   const prNumber = parseOptionalPrNumber();
   const mode = prNumber ? "update" : "initial";
   const initialSnapshot = mode === "update" ? await publish("/pr/snapshot", { target_repository: repository, pull_request: prNumber }) : null;
@@ -37,6 +38,7 @@ $("submit").addEventListener("click", run(async () => {
     prompt,
     mode,
     handoff_mode: $("handoff-mode").value,
+    evidence_policy: evidencePolicy,
     repository,
     storage,
     pull_request: prNumber,
@@ -90,7 +92,11 @@ async function finalizeInitial() {
   if (!["running", "ready"].includes(taskState.phase)) throw new Error(`initial task cannot finalize from phase ${taskState.phase}`);
   taskState.phase = "finalizing"; await saveTaskState(); setStatus("Creating PR and recording task provenance…");
   try {
-    const result = await send({ type: "crossdock.createPrAndInspect", targetRepository: taskState.repository });
+    const result = await send({
+      type: "crossdock.createPrAndInspect",
+      targetRepository: taskState.repository,
+      captureReport: taskState.evidence_policy.report !== "omit",
+    });
     const prNumber = parsePrNumber(result.prUrl, taskState.repository);
     $("pull-request").value = String(prNumber);
     await publish("/handoff/initial", { storage: taskState.storage, task: buildTask({ repository: taskState.repository, prNumber, result }), pr: buildDescription() });
@@ -103,7 +109,10 @@ async function finalizeUpdate() {
   if (!["running", "ready"].includes(taskState.phase)) throw new Error(`update task cannot finalize from phase ${taskState.phase}`);
   taskState.phase = "finalizing"; await saveTaskState(); setStatus("Updating the PR branch and verifying the remote head…");
   try {
-    const result = await send({ type: "crossdock.applyBranchUpdate" });
+    const result = await send({
+      type: "crossdock.applyBranchUpdate",
+      captureReport: taskState.evidence_policy.report !== "omit",
+    });
     taskState.phase = "branch-update-clicked";
     taskState.final_task_url = result.taskUrl;
     taskState.final_report = result.report;
@@ -152,7 +161,7 @@ async function completeTask(prNumber) {
 
 function buildTask({ repository, prNumber, result }) {
   const issueText = $("issue").value.trim();
-  return {
+  const record = {
     task_id: taskState.task_id,
     created_at: taskState.created_at,
     completed_at: new Date().toISOString(),
@@ -160,9 +169,11 @@ function buildTask({ repository, prNumber, result }) {
     pull_request: prNumber,
     issue: issueText ? Number(issueText) : null,
     agent_task_url: result.taskUrl,
-    prompt: taskState.prompt,
-    report: result.report,
+    evidence_policy: taskState.evidence_policy,
   };
+  if (taskState.evidence_policy.prompt !== "omit") record.prompt = taskState.prompt;
+  if (taskState.evidence_policy.report !== "omit") record.report = result.report;
+  return record;
 }
 
 function buildDescription() {
@@ -170,6 +181,14 @@ function buildDescription() {
     summary: $("summary").value.trim() || "Completed the delegated task.",
     validation: $("validation").value.split(/\r?\n/).map((line) => line.trim()).filter(Boolean),
   };
+}
+
+function readEvidencePolicy() {
+  const prompt = $("prompt-evidence").value;
+  const report = $("report-evidence").value;
+  const allowed = new Set(["full", "hash", "omit"]);
+  if (!allowed.has(prompt) || !allowed.has(report)) throw new Error("invalid evidence policy");
+  return { prompt, report };
 }
 
 function requireStorage() {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 export { GitHubClient } from "./github-client.js";
 export { buildPrBody, buildUpdateComment, persistTaskLog, publishExistingInitialHandoff, publishInitialHandoff, publishUpdateHandoff } from "./handoff.js";
-export { TASK_LOG_SCHEMA, assertGithubSafe, canonicalizeText, renderTaskLog, sha256, taskLogPath, validateTaskRecord } from "./task-log.js";
+export { EVIDENCE_MODES, TASK_LOG_SCHEMA, assertGithubSafe, canonicalizeText, evidencePolicy, renderTaskLog, sha256, taskLogPath, validateTaskRecord } from "./task-log.js";
 export { createHandoffServer } from "./http-server.js";
 export { dispatchHandoff, hydrateTaskFromPullRequest } from "./service.js";

--- a/src/task-log.js
+++ b/src/task-log.js
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
-export const TASK_LOG_SCHEMA = "crossdock.task-record/v1";
+export const TASK_LOG_SCHEMA = "crossdock.task-record/v2";
+export const EVIDENCE_MODES = Object.freeze(["full", "hash", "omit"]);
 
 const FORBIDDEN_PATTERNS = [
   /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/i,
@@ -41,14 +42,33 @@ function assertTimestamp(value, field) {
   if (Number.isNaN(Date.parse(value))) throw new Error(`${field} must be an RFC 3339 timestamp`);
 }
 
+function normalizeEvidenceMode(value, field) {
+  const mode = value ?? "full";
+  if (!EVIDENCE_MODES.includes(mode)) throw new Error(`${field} evidence mode must be one of: ${EVIDENCE_MODES.join(", ")}`);
+  return mode;
+}
+
+export function evidencePolicy(record) {
+  const policy = record?.evidence_policy;
+  if (policy != null && (typeof policy !== "object" || Array.isArray(policy))) throw new Error("evidence_policy must be an object");
+  return {
+    prompt: normalizeEvidenceMode(policy?.prompt, "prompt"),
+    report: normalizeEvidenceMode(policy?.report, "report"),
+  };
+}
+
+function validateEvidence(record, field, mode) {
+  if (mode === "omit") return;
+  requireString(record, field);
+  if (mode === "full") assertGithubSafe(record[field], field);
+}
+
 export function validateTaskRecord(record) {
   if (!record || typeof record !== "object") throw new TypeError("record is required");
   requireString(record, "task_id");
   requireString(record, "target_repository");
   requireString(record, "base_branch");
   requireString(record, "working_branch");
-  requireString(record, "prompt");
-  requireString(record, "report");
   assertTimestamp(record.created_at, "created_at");
   assertTimestamp(record.completed_at, "completed_at");
 
@@ -58,8 +78,9 @@ export function validateTaskRecord(record) {
   if (record.task_type === "initial" && record.parent_task_id != null) throw new Error("initial task parent_task_id must be null");
   if (record.task_type === "update" && !record.pull_request) throw new Error("update task requires pull_request");
 
-  assertGithubSafe(record.prompt, "prompt");
-  assertGithubSafe(record.report, "report");
+  const policy = evidencePolicy(record);
+  validateEvidence(record, "prompt", policy.prompt);
+  validateEvidence(record, "report", policy.report);
   return record;
 }
 
@@ -72,18 +93,30 @@ export function taskLogPath(record) {
   return `crossdock/tasks/${owner}/${repo}/${year}/${month}/${record.task_id}.md`;
 }
 
+function evidenceDigest(record, field, mode) {
+  if (mode === "omit") return null;
+  return sha256(record[field]);
+}
+
+function evidenceSection(record, field, title, mode) {
+  if (mode !== "full") return "";
+  return `\n## ${title}\n\n${canonicalizeText(record[field])}\n`;
+}
+
 export function renderTaskLog(record) {
   validateTaskRecord(record);
-  const prompt = canonicalizeText(record.prompt);
-  const report = canonicalizeText(record.report);
+  const policy = evidencePolicy(record);
   const fields = [
     ["schema", TASK_LOG_SCHEMA], ["task_id", record.task_id], ["task_type", record.task_type], ["status", "completed"],
     ["created_at", record.created_at], ["completed_at", record.completed_at], ["target_repository", record.target_repository],
     ["base_branch", record.base_branch], ["working_branch", record.working_branch], ["pull_request", record.pull_request ?? null],
     ["issue", record.issue ?? null], ["agent_task_url", record.agent_task_url ?? record.codex_task_url ?? null],
     ["result_commit", record.result_commit ?? null], ["parent_task_id", record.parent_task_id ?? null],
-    ["prompt_sha256", sha256(prompt)], ["report_sha256", sha256(report)],
+    ["prompt_evidence", policy.prompt], ["report_evidence", policy.report],
+    ["prompt_sha256", evidenceDigest(record, "prompt", policy.prompt)], ["report_sha256", evidenceDigest(record, "report", policy.report)],
   ];
   const frontMatter = fields.map(([key, value]) => `${key}: ${quoteYaml(value)}`).join("\n");
-  return `---\n${frontMatter}\n---\n\n# Crossdock Task\n\n## Prompt\n\n${prompt}\n\n## Report\n\n${report}\n`;
+  const prompt = evidenceSection(record, "prompt", "Prompt", policy.prompt);
+  const report = evidenceSection(record, "report", "Report", policy.report);
+  return `---\n${frontMatter}\n---\n\n# Crossdock Task\n${prompt}${report}`;
 }

--- a/tests/task-log.test.js
+++ b/tests/task-log.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { canonicalizeText, renderTaskLog, sha256, taskLogPath } from "../src/task-log.js";
+import { canonicalizeText, evidencePolicy, renderTaskLog, sha256, taskLogPath } from "../src/task-log.js";
 
 function baseRecord(overrides = {}) {
   return {
@@ -13,9 +13,13 @@ function baseRecord(overrides = {}) {
 
 test("canonicalizeText normalizes CRLF and CR to LF", () => assert.equal(canonicalizeText("a\r\nb\rc\n"), "a\nb\nc\n"));
 
-test("renderTaskLog preserves canonical prompt and report with digests", () => {
-  const record = baseRecord(); const rendered = renderTaskLog(record);
-  assert.match(rendered, /schema: "crossdock\.task-record\/v1"/);
+test("default evidence policy retains full prompt and report", () => {
+  assert.deepEqual(evidencePolicy(baseRecord()), { prompt: "full", report: "full" });
+  const record = baseRecord();
+  const rendered = renderTaskLog(record);
+  assert.match(rendered, /schema: "crossdock\.task-record\/v2"/);
+  assert.match(rendered, /prompt_evidence: "full"/);
+  assert.match(rendered, /report_evidence: "full"/);
   assert.match(rendered, new RegExp(`prompt_sha256: "${sha256(record.prompt)}"`));
   assert.match(rendered, new RegExp(`report_sha256: "${sha256(record.report)}"`));
   assert.match(rendered, /## Prompt\n\nDo the thing\.\nPreserve invariants\.\n/);
@@ -23,8 +27,65 @@ test("renderTaskLog preserves canonical prompt and report with digests", () => {
   assert.ok(!rendered.includes("\r"));
 });
 
+test("prompt-only retention omits report content and digest", () => {
+  const rendered = renderTaskLog(baseRecord({ evidence_policy: { prompt: "full", report: "omit" } }));
+  assert.match(rendered, /prompt_evidence: "full"/);
+  assert.match(rendered, /report_evidence: "omit"/);
+  assert.match(rendered, /report_sha256: null/);
+  assert.match(rendered, /## Prompt/);
+  assert.ok(!rendered.includes("## Report"));
+  assert.ok(!rendered.includes("Done."));
+});
+
+test("report-only retention omits prompt content and digest", () => {
+  const rendered = renderTaskLog(baseRecord({ evidence_policy: { prompt: "omit", report: "full" } }));
+  assert.match(rendered, /prompt_evidence: "omit"/);
+  assert.match(rendered, /prompt_sha256: null/);
+  assert.ok(!rendered.includes("## Prompt"));
+  assert.ok(!rendered.includes("Do the thing."));
+  assert.match(rendered, /## Report/);
+});
+
+test("metadata-only retention permits absent prompt and report", () => {
+  const record = baseRecord({ evidence_policy: { prompt: "omit", report: "omit" } });
+  delete record.prompt;
+  delete record.report;
+  const rendered = renderTaskLog(record);
+  assert.match(rendered, /prompt_evidence: "omit"/);
+  assert.match(rendered, /report_evidence: "omit"/);
+  assert.match(rendered, /prompt_sha256: null/);
+  assert.match(rendered, /report_sha256: null/);
+  assert.ok(!rendered.includes("## Prompt"));
+  assert.ok(!rendered.includes("## Report"));
+});
+
+test("hash-only evidence stores digest without plaintext", () => {
+  const record = baseRecord({ evidence_policy: { prompt: "hash", report: "hash" } });
+  const rendered = renderTaskLog(record);
+  assert.match(rendered, /prompt_evidence: "hash"/);
+  assert.match(rendered, /report_evidence: "hash"/);
+  assert.match(rendered, new RegExp(`prompt_sha256: "${sha256(record.prompt)}"`));
+  assert.match(rendered, new RegExp(`report_sha256: "${sha256(record.report)}"`));
+  assert.ok(!rendered.includes("Do the thing."));
+  assert.ok(!rendered.includes("Done."));
+});
+
+test("omitted and hash-only evidence does not persist secret-like plaintext", () => {
+  const secret = "access_token=ghp_abcdefghijklmnopqrstuvwxyz123456";
+  assert.doesNotThrow(() => renderTaskLog(baseRecord({ prompt: secret, evidence_policy: { prompt: "omit", report: "full" } })));
+  const hashed = renderTaskLog(baseRecord({ prompt: secret, evidence_policy: { prompt: "hash", report: "full" } }));
+  assert.ok(!hashed.includes(secret));
+  assert.match(hashed, new RegExp(sha256(secret)));
+});
+
+test("known secret-like material fails closed when plaintext would be persisted", () => {
+  assert.throws(() => renderTaskLog(baseRecord({ prompt: "access_token=ghp_abcdefghijklmnopqrstuvwxyz123456" })), /Forbidden-from-GitHub/);
+});
+
+test("unsupported evidence modes fail clearly", () => {
+  assert.throws(() => renderTaskLog(baseRecord({ evidence_policy: { prompt: "sometimes", report: "full" } })), /prompt evidence mode/);
+});
+
 test("taskLogPath is deterministic", () => assert.equal(taskLogPath(baseRecord()), "crossdock/tasks/example/project/2026/08/task-001.md"));
 
 test("update tasks require a pull request", () => assert.throws(() => renderTaskLog(baseRecord({ task_type: "update", pull_request: null, parent_task_id: "task-001" })), /update task requires pull_request/));
-
-test("known secret-like material fails closed", () => assert.throws(() => renderTaskLog(baseRecord({ prompt: "access_token=ghp_abcdefghijklmnopqrstuvwxyz123456" })), /Forbidden-from-GitHub/));


### PR DESCRIPTION
## Summary

- introduces `crossdock.task-record/v2` with independent prompt/report evidence policies
- supports `full`, `hash`, and `omit` for each evidence class, covering full, prompt-only, report-only, metadata-only, and mixed profiles
- exposes prompt/report evidence controls in the dashboard
- avoids scraping/capturing the final report when report evidence is explicitly omitted
- documents the schema and a provider-neutral public live-test procedure
- records the separate transient/recovery data-lifecycle boundary in public issue #19

## Governance

Company governance now authorizes configurable task evidence retention while preserving truthful provenance, classification, immutability, PR linkage, and independent review.

## Validation

CI should run `npm test` and `npm run check` on Node 22. This PR adds focused tests for all current evidence modes and secret-like plaintext behavior.

Relates to #8 and #19.