### PR TITLE
feat: make handoff retries idempotent

### DIFF
--- a/src/github-client.js
+++ b/src/github-client.js
@@ -45,6 +45,15 @@ export class GitHubClient {
     return this.request("GET", `/repos/${owner}/${repo}/contents/${encodePath(path)}${query}`);
   }
 
+  async getLatestCommitForPath(repository, path, ref) {
+    const [owner, repo] = repository.split("/");
+    const params = new URLSearchParams({ path, per_page: "1" });
+    if (ref) params.set("sha", ref);
+    const commits = await this.request("GET", `/repos/${owner}/${repo}/commits?${params}`);
+    if (!Array.isArray(commits) || !commits[0]?.sha) throw new Error("GitHub did not return a commit for the task-record path");
+    return commits[0];
+  }
+
   createPullRequest(repository, { title, body, head, base, draft = false }) {
     const [owner, repo] = repository.split("/");
     return this.request("POST", `/repos/${owner}/${repo}/pulls`, { title, body, head, base, draft });

--- a/src/handoff.js
+++ b/src/handoff.js
@@ -63,10 +63,18 @@ export async function publishUpdateHandoff({ github, storage, task, update }) {
   const record = { ...task, task_type: "update" };
   const persisted = await persistTaskLog({ github, storage: destination, record });
   const commentBody = buildUpdateComment({ summary: update.summary, validation: update.validation, logUrl: persisted.url, commit: task.result_commit });
-  const comment = await github.addIssueComment(task.target_repository, task.pull_request, commentBody);
+
+  const before = await github.getIssueComments(task.target_repository, task.pull_request);
+  const linked = before.filter((item) => typeof item.body === "string" && item.body.includes(persisted.url));
+  const conflicting = linked.find((item) => item.body !== commentBody);
+  if (conflicting) throw new Error("update handoff retry conflict: existing task-record comment has different content");
+
+  let comment = linked.find((item) => item.body === commentBody) ?? null;
+  if (!comment) comment = await github.addIssueComment(task.target_repository, task.pull_request, commentBody);
+
   const comments = await github.getIssueComments(task.target_repository, task.pull_request);
-  const verifiedComment = comments.find((item) => item.id === comment.id);
-  if (!verifiedComment?.body?.includes(persisted.url)) throw new Error("update handoff verification failed: durable PR comment does not link task record");
+  const verifiedComment = comments.find((item) => item.id === comment.id && item.body === commentBody);
+  if (!verifiedComment) throw new Error("update handoff verification failed: durable PR comment does not match expected task record linkage");
   await verifyTaskLog({ github, storage: destination, path: persisted.path, ref: persisted.commitSha, expectedContent: persisted.content });
   return { comment: verifiedComment, taskLog: persisted };
 }
@@ -75,10 +83,26 @@ export async function persistTaskLog({ github, storage, record }) {
   const destination = requireStorage(storage);
   const path = taskLogPath(record);
   const content = renderTaskLog(record);
-  const response = await github.createFile(destination.repository, path, content, `crossdock: record task ${record.task_id}`, destination.branch);
-  const commitSha = response.commit?.sha;
-  if (!commitSha) throw new Error("task-record persistence did not return a commit SHA");
-  const url = `https://github.com/${destination.repository}/blob/${commitSha}/${path}`;
+
+  try {
+    const response = await github.createFile(destination.repository, path, content, `crossdock: record task ${record.task_id}`, destination.branch);
+    const commitSha = response.commit?.sha;
+    if (!commitSha) throw new Error("task-record persistence did not return a commit SHA");
+    return persistedTaskLog(destination.repository, path, content, commitSha);
+  } catch (error) {
+    if (![409, 422].includes(error?.status)) throw error;
+  }
+
+  const existing = await github.getFile(destination.repository, path, destination.branch);
+  const actual = decodeFileContent(existing, "task-record retry recovery");
+  if (actual !== content) throw new Error("task-record retry conflict: existing immutable record has different content");
+
+  const commit = await github.getLatestCommitForPath(destination.repository, path, destination.branch);
+  return persistedTaskLog(destination.repository, path, content, commit.sha);
+}
+
+function persistedTaskLog(repository, path, content, commitSha) {
+  const url = `https://github.com/${repository}/blob/${commitSha}/${path}`;
   return { path, content, commitSha, url };
 }
 
@@ -89,9 +113,13 @@ function requireStorage(storage) {
   return storage;
 }
 
+function decodeFileContent(file, context) {
+  if (!file?.sha || typeof file.content !== "string") throw new Error(`${context} failed: remote file missing content`);
+  return Buffer.from(file.content.replace(/\n/g, ""), "base64").toString("utf8");
+}
+
 async function verifyTaskLog({ github, storage, path, ref, expectedContent }) {
   const file = await github.getFile(storage.repository, path, ref);
-  if (!file?.sha || typeof file.content !== "string") throw new Error("task-record verification failed: remote file missing content");
-  const actual = Buffer.from(file.content.replace(/\n/g, ""), "base64").toString("utf8");
+  const actual = decodeFileContent(file, "task-record verification");
   if (actual !== expectedContent) throw new Error("task-record verification failed: remote content mismatch");
 }

--- a/tests/github-client.test.js
+++ b/tests/github-client.test.js
@@ -9,6 +9,25 @@ test("GitHubClient creates UTF-8 files with base64 content", async () => {
   const [url, options] = calls[0]; assert.equal(url, "https://api.github.com/repos/example/private-task-records/contents/crossdock/tasks/a%20b.md"); assert.equal(options.method, "PUT"); assert.equal(options.headers.Authorization, "Bearer test-token");
 });
 
+test("GitHubClient resolves latest commit for an immutable task-record path", async () => {
+  const calls = [];
+  const client = new GitHubClient({ token: "test-token", fetchImpl: async (url, options) => { calls.push([url, options]); return response(200, [{ sha: "record-commit" }]); } });
+  const commit = await client.getLatestCommitForPath("example/private-task-records", "crossdock/tasks/example/project/task 1.md", "records/main");
+  assert.equal(commit.sha, "record-commit");
+  const [url, options] = calls[0];
+  assert.equal(options.method, "GET");
+  const parsed = new URL(url);
+  assert.equal(parsed.pathname, "/repos/example/private-task-records/commits");
+  assert.equal(parsed.searchParams.get("path"), "crossdock/tasks/example/project/task 1.md");
+  assert.equal(parsed.searchParams.get("sha"), "records/main");
+  assert.equal(parsed.searchParams.get("per_page"), "1");
+});
+
+test("GitHubClient rejects missing commit lookup results", async () => {
+  const client = new GitHubClient({ token: "test-token", fetchImpl: async () => response(200, []) });
+  await assert.rejects(client.getLatestCommitForPath("example/private-task-records", "task.md", "main"), /did not return a commit/);
+});
+
 test("GitHubClient exposes GitHub error status and payload", async () => {
   const client = new GitHubClient({ token: "test-token", fetchImpl: async () => response(422, { message: "Validation Failed" }) });
   await assert.rejects(client.getPullRequest("example/project", 1), (error) => error.status === 422 && error.payload.message === "Validation Failed");

--- a/tests/handoff.test.js
+++ b/tests/handoff.test.js
@@ -1,26 +1,101 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { publishInitialHandoff, publishUpdateHandoff } from "../src/handoff.js";
+import { persistTaskLog, publishInitialHandoff, publishUpdateHandoff } from "../src/handoff.js";
 
 const storage = { repository: "example/private-task-records", branch: "main" };
 function task(overrides = {}) { return { task_id: "task-001", created_at: "2026-08-31T20:00:00Z", completed_at: "2026-08-31T20:05:00Z", target_repository: "example/project", base_branch: "main", working_branch: "crossdock/task-001", issue: 123, agent_task_url: "https://example.invalid/tasks/task-001", result_commit: "0123456789abcdef0123456789abcdef01234567", prompt: "Implement the bounded task.", report: "## Summary\n\nImplemented and validated.", ...overrides }; }
+
+function conflictError(status = 422) { const error = new Error("already exists"); error.status = status; return error; }
+
 function mockGithub() {
-  const calls = []; let prBody = null; let storedContent = null; let storedComment = null;
-  return { calls,
+  const calls = [];
+  let prBody = null;
+  let storedContent = null;
+  let fileCreated = false;
+  let storedComment = null;
+  return {
+    calls,
+    setStoredContent(value) { storedContent = value; fileCreated = true; },
+    setStoredCommentBody(value) { if (!storedComment) throw new Error("no comment to mutate"); storedComment = { ...storedComment, body: value }; },
     async createPullRequest(repository, payload) { calls.push(["createPullRequest", repository, payload]); prBody = payload.body; return { number: 77, body: prBody }; },
-    async createFile(repository, path, content, message, branch) { calls.push(["createFile", repository, path, content, message, branch]); storedContent = content; return { commit: { sha: "abc123" }, content: { sha: "blob123" } }; },
+    async createFile(repository, path, content, message, branch) {
+      calls.push(["createFile", repository, path, content, message, branch]);
+      if (fileCreated) throw conflictError();
+      fileCreated = true;
+      storedContent = content;
+      return { commit: { sha: "abc123" }, content: { sha: "blob123" } };
+    },
+    async getLatestCommitForPath(repository, path, ref) { calls.push(["getLatestCommitForPath", repository, path, ref]); return { sha: "abc123" }; },
     async updatePullRequest(repository, number, payload) { calls.push(["updatePullRequest", repository, number, payload]); prBody = payload.body; return { number, body: prBody }; },
     async getPullRequest(repository, number) { calls.push(["getPullRequest", repository, number]); return { number, body: prBody }; },
-    async getFile(repository, path, ref) { calls.push(["getFile", repository, path, ref]); return { sha: "blob123", content: Buffer.from(storedContent, "utf8").toString("base64") }; },
+    async getFile(repository, path, ref) { calls.push(["getFile", repository, path, ref]); return { sha: "blob123", content: Buffer.from(storedContent ?? "", "utf8").toString("base64") }; },
     async addIssueComment(repository, number, body) { calls.push(["addIssueComment", repository, number, body]); storedComment = { id: 9, body }; return storedComment; },
     async getIssueComments(repository, number) { calls.push(["getIssueComments", repository, number]); return storedComment ? [storedComment] : []; },
   };
 }
 
-test("storage must be explicit before mutation", async () => { const github = mockGithub(); await assert.rejects(publishInitialHandoff({ github, task: task(), pr: { title: "change", summary: "summary" } }), /storage must be configured explicitly/); assert.deepEqual(github.calls, []); });
+test("storage must be explicit before mutation", async () => {
+  const github = mockGithub();
+  await assert.rejects(publishInitialHandoff({ github, task: task(), pr: { title: "change", summary: "summary" } }), /storage must be configured explicitly/);
+  assert.deepEqual(github.calls, []);
+});
 
-test("initial handoff persists configured record and verifies", async () => { const github = mockGithub(); const result = await publishInitialHandoff({ github, storage, task: task(), pr: { title: "test: bounded change", summary: "Implements the bounded change.", validation: ["tests passed"] } }); assert.equal(result.pullRequest.number, 77); assert.equal(result.taskLog.url, "https://github.com/example/private-task-records/blob/abc123/crossdock/tasks/example/project/2026/08/task-001.md"); assert.match(result.pullRequest.body, /Task record:/); assert.deepEqual(github.calls.map(([name]) => name), ["createPullRequest", "createFile", "updatePullRequest", "getPullRequest", "getFile"]); });
+test("initial handoff persists configured record and verifies", async () => {
+  const github = mockGithub();
+  const result = await publishInitialHandoff({ github, storage, task: task(), pr: { title: "test: bounded change", summary: "Implements the bounded change.", validation: ["tests passed"] } });
+  assert.equal(result.pullRequest.number, 77);
+  assert.equal(result.taskLog.url, "https://github.com/example/private-task-records/blob/abc123/crossdock/tasks/example/project/2026/08/task-001.md");
+  assert.match(result.pullRequest.body, /Task record:/);
+  assert.deepEqual(github.calls.map(([name]) => name), ["createPullRequest", "createFile", "updatePullRequest", "getPullRequest", "getFile"]);
+});
 
-test("forbidden content fails before PR creation", async () => { const github = mockGithub(); await assert.rejects(publishInitialHandoff({ github, storage, task: task({ prompt: "access_token=ghp_abcdefghijklmnopqrstuvwxyz123456" }), pr: { title: "change", summary: "summary" } }), /Forbidden-from-GitHub/); assert.deepEqual(github.calls, []); });
+test("forbidden content fails before PR creation", async () => {
+  const github = mockGithub();
+  await assert.rejects(publishInitialHandoff({ github, storage, task: task({ prompt: "access_token=ghp_abcdefghijklmnopqrstuvwxyz123456" }), pr: { title: "change", summary: "summary" } }), /Forbidden-from-GitHub/);
+  assert.deepEqual(github.calls, []);
+});
 
-test("update handoff adds a new top-level comment without editing PR", async () => { const github = mockGithub(); const result = await publishUpdateHandoff({ github, storage, task: task({ task_id: "task-002", pull_request: 77, parent_task_id: "task-001" }), update: { summary: "Addressed review findings.", validation: ["tests passed"] } }); assert.match(result.comment.body, /Crossdock branch update/); assert.ok(!github.calls.some(([name]) => name === "updatePullRequest")); });
+test("task-record retry reuses an exact immutable record", async () => {
+  const github = mockGithub();
+  const record = { ...task(), task_type: "initial", parent_task_id: null };
+  const first = await persistTaskLog({ github, storage, record });
+  const second = await persistTaskLog({ github, storage, record });
+  assert.deepEqual(second, first);
+  assert.equal(github.calls.filter(([name]) => name === "createFile").length, 2);
+  assert.equal(github.calls.filter(([name]) => name === "getLatestCommitForPath").length, 1);
+});
+
+test("task-record retry fails closed when existing content differs", async () => {
+  const github = mockGithub();
+  const record = { ...task(), task_type: "initial", parent_task_id: null };
+  await persistTaskLog({ github, storage, record });
+  github.setStoredContent("conflicting immutable content\n");
+  await assert.rejects(persistTaskLog({ github, storage, record }), /existing immutable record has different content/);
+});
+
+test("update handoff adds a new top-level comment without editing PR", async () => {
+  const github = mockGithub();
+  const result = await publishUpdateHandoff({ github, storage, task: task({ task_id: "task-002", pull_request: 77, parent_task_id: "task-001" }), update: { summary: "Addressed review findings.", validation: ["tests passed"] } });
+  assert.match(result.comment.body, /Crossdock branch update/);
+  assert.ok(!github.calls.some(([name]) => name === "updatePullRequest"));
+});
+
+test("update retry reuses the exact existing task-record comment", async () => {
+  const github = mockGithub();
+  const updateTask = task({ task_id: "task-002", pull_request: 77, parent_task_id: "task-001" });
+  const update = { summary: "Addressed review findings.", validation: ["tests passed"] };
+  const first = await publishUpdateHandoff({ github, storage, task: updateTask, update });
+  const second = await publishUpdateHandoff({ github, storage, task: updateTask, update });
+  assert.equal(second.comment.id, first.comment.id);
+  assert.equal(github.calls.filter(([name]) => name === "addIssueComment").length, 1);
+});
+
+test("update retry fails closed on conflicting comment for the same task record", async () => {
+  const github = mockGithub();
+  const updateTask = task({ task_id: "task-002", pull_request: 77, parent_task_id: "task-001" });
+  const update = { summary: "Addressed review findings.", validation: ["tests passed"] };
+  const first = await publishUpdateHandoff({ github, storage, task: updateTask, update });
+  github.setStoredCommentBody(`${first.comment.body}\nconflicting edit\n`);
+  await assert.rejects(publishUpdateHandoff({ github, storage, task: updateTask, update }), /existing task-record comment has different content/);
+  assert.equal(github.calls.filter(([name]) => name === "addIssueComment").length, 1);
+});


### PR DESCRIPTION
## Summary

- recovers an already-created immutable task record only when its remote bytes exactly match the expected rendered record
- resolves the original task-record commit SHA for stable immutable links
- fails closed when an existing task-record path contains conflicting content
- reuses an exact existing update comment on retry instead of creating duplicates
- fails closed when a comment already links the task record with conflicting content
- adds focused GitHub-client and handoff retry tests

## Validation

CI should run `npm test` and `npm run check` on Node 22.