### PR TITLE
fix: recover uncertain initial PR creation

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -29,12 +29,19 @@ async function handleMessage(message) {
     }
     case "crossdock.createPrAndInspect": {
       const tab = await findChatGptTab(true);
-      const beforeTabs = await matchingPrTabUrls(message.targetRepository);
-      const beforePage = (await sendToTab(tab.id, { type: "crossdock.findPrUrls", targetRepository: message.targetRepository })).prUrls;
+      const beforeTabs = (await matchingPrTabUrls(message.targetRepository)).map((url) => canonicalPrUrl(url, message.targetRepository));
+      const beforePage = (await sendToTab(tab.id, { type: "crossdock.findPrUrls", targetRepository: message.targetRepository })).prUrls
+        .map((url) => canonicalPrUrl(url, message.targetRepository));
       const discovery = { beforeTabs, beforePage };
       const prepared = await sendToTab(tab.id, { type: "crossdock.prepareCreatePr", captureReport: message.captureReport !== false });
-      const prUrl = await waitForPrUrl({ tabId: tab.id, targetRepository: message.targetRepository, discovery });
-      return { ...prepared, prUrl, discovery, uncertain: !prUrl };
+      let prUrl = null;
+      let discoveryError = null;
+      try {
+        prUrl = await waitForPrUrl({ tabId: tab.id, targetRepository: message.targetRepository, discovery });
+      } catch (error) {
+        discoveryError = error.message;
+      }
+      return { ...prepared, prUrl, discovery, discoveryError, uncertain: !prUrl };
     }
     case "crossdock.recoverCreatedPr": {
       const tab = await findChatGptTab(true);
@@ -106,16 +113,34 @@ async function findNewPrUrls({ tabId, targetRepository, discovery }) {
   if (!discovery || !Array.isArray(discovery.beforeTabs) || !Array.isArray(discovery.beforePage)) {
     throw new Error("created PR recovery baseline is missing");
   }
-  const beforeTabs = new Set(discovery.beforeTabs);
-  const beforePage = new Set(discovery.beforePage);
-  const candidates = new Set((await matchingPrTabUrls(targetRepository)).filter((url) => !beforeTabs.has(url)));
+  const beforeTabs = new Set(discovery.beforeTabs.map((url) => canonicalPrUrl(url, targetRepository)));
+  const beforePage = new Set(discovery.beforePage.map((url) => canonicalPrUrl(url, targetRepository)));
+  const candidates = new Set(
+    (await matchingPrTabUrls(targetRepository))
+      .map((url) => canonicalPrUrl(url, targetRepository))
+      .filter((url) => !beforeTabs.has(url)),
+  );
   try {
     const current = await sendToTab(tabId, { type: "crossdock.findPrUrls", targetRepository });
-    for (const url of current.prUrls) if (!beforePage.has(url)) candidates.add(url);
+    for (const value of current.prUrls) {
+      const url = canonicalPrUrl(value, targetRepository);
+      if (!beforePage.has(url)) candidates.add(url);
+    }
   } catch {
     // Provider navigation may temporarily make the content script unavailable; GitHub tabs remain valid evidence.
   }
   return [...candidates];
+}
+
+function canonicalPrUrl(value, targetRepository) {
+  if (typeof value !== "string") throw new Error("PR URL must be a string");
+  if (typeof targetRepository !== "string" || !/^[^/\s]+\/[^/\s]+$/.test(targetRepository)) throw new Error("target repository must be owner/repo");
+  const parsed = new URL(value);
+  if (parsed.origin !== "https://github.com") throw new Error("PR URL must use github.com");
+  const escaped = targetRepository.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = parsed.pathname.match(new RegExp(`^/${escaped}/pull/(\\d+)/?$`));
+  if (!match) throw new Error("PR URL does not identify the target repository");
+  return `https://github.com/${targetRepository}/pull/${match[1]}`;
 }
 
 async function matchingPrTabUrls(targetRepository) {

--- a/extension/background.js
+++ b/extension/background.js
@@ -29,11 +29,18 @@ async function handleMessage(message) {
     }
     case "crossdock.createPrAndInspect": {
       const tab = await findChatGptTab(true);
-      const beforeTabs = new Set(await matchingPrTabUrls(message.targetRepository));
-      const beforePage = new Set((await sendToTab(tab.id, { type: "crossdock.findPrUrls", targetRepository: message.targetRepository })).prUrls);
+      const beforeTabs = await matchingPrTabUrls(message.targetRepository);
+      const beforePage = (await sendToTab(tab.id, { type: "crossdock.findPrUrls", targetRepository: message.targetRepository })).prUrls;
+      const discovery = { beforeTabs, beforePage };
       const prepared = await sendToTab(tab.id, { type: "crossdock.prepareCreatePr", captureReport: message.captureReport !== false });
-      const prUrl = await waitForPrUrl({ tabId: tab.id, targetRepository: message.targetRepository, beforeTabs, beforePage });
-      return { ...prepared, prUrl };
+      const prUrl = await waitForPrUrl({ tabId: tab.id, targetRepository: message.targetRepository, discovery });
+      return { ...prepared, prUrl, discovery, uncertain: !prUrl };
+    }
+    case "crossdock.recoverCreatedPr": {
+      const tab = await findChatGptTab(true);
+      const candidates = await findNewPrUrls({ tabId: tab.id, targetRepository: message.targetRepository, discovery: message.discovery });
+      if (candidates.length > 1) throw new Error(`created PR recovery is ambiguous; found ${candidates.length} new target-repository PR URLs`);
+      return { prUrl: candidates[0] ?? null };
     }
     case "crossdock.applyBranchUpdate": {
       const tab = await findChatGptTab(true);
@@ -84,20 +91,31 @@ async function activateOrCreate(url, codex) {
   return chrome.tabs.create({ url, active: true });
 }
 
-async function waitForPrUrl({ tabId, targetRepository, beforeTabs, beforePage }) {
+async function waitForPrUrl({ tabId, targetRepository, discovery }) {
   const deadline = Date.now() + 60_000;
   while (Date.now() < deadline) {
-    const tabUrls = await matchingPrTabUrls(targetRepository);
-    const newTabUrl = tabUrls.find((url) => !beforeTabs.has(url));
-    if (newTabUrl) return newTabUrl;
-    try {
-      const current = await sendToTab(tabId, { type: "crossdock.findPrUrls", targetRepository });
-      const newPageUrl = current.prUrls.find((url) => !beforePage.has(url));
-      if (newPageUrl) return newPageUrl;
-    } catch {}
+    const candidates = await findNewPrUrls({ tabId, targetRepository, discovery });
+    if (candidates.length > 1) throw new Error(`created PR discovery is ambiguous; found ${candidates.length} new target-repository PR URLs`);
+    if (candidates.length === 1) return candidates[0];
     await new Promise((resolve) => setTimeout(resolve, 500));
   }
-  throw new Error("timed out waiting for coding-agent-created PR URL");
+  return null;
+}
+
+async function findNewPrUrls({ tabId, targetRepository, discovery }) {
+  if (!discovery || !Array.isArray(discovery.beforeTabs) || !Array.isArray(discovery.beforePage)) {
+    throw new Error("created PR recovery baseline is missing");
+  }
+  const beforeTabs = new Set(discovery.beforeTabs);
+  const beforePage = new Set(discovery.beforePage);
+  const candidates = new Set((await matchingPrTabUrls(targetRepository)).filter((url) => !beforeTabs.has(url)));
+  try {
+    const current = await sendToTab(tabId, { type: "crossdock.findPrUrls", targetRepository });
+    for (const url of current.prUrls) if (!beforePage.has(url)) candidates.add(url);
+  } catch {
+    // Provider navigation may temporarily make the content script unavailable; GitHub tabs remain valid evidence.
+  }
+  return [...candidates];
 }
 
 async function matchingPrTabUrls(targetRepository) {

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -61,6 +61,20 @@ async function monitorTask() {
   monitoring = true;
   try {
     while (taskState) {
+      if (taskState.phase === "pr-create-uncertain") {
+        try {
+          const recovered = await recoverInitialPrCreation();
+          if (!recovered) {
+            setStatus("Create PR was invoked, but the resulting PR URL is not visible yet. Waiting without invoking Create PR again…");
+            await sleep(POLL_MS);
+          }
+          continue;
+        } catch (error) {
+          setStatus(`Recovering created PR: ${error.message}. Will retry without invoking Create PR again.`, true);
+          await sleep(POLL_MS);
+          continue;
+        }
+      }
       if (taskState.phase === "pr-created") {
         try {
           await finishInitialAfterPrCreated();
@@ -118,25 +132,53 @@ async function finalizeInitial() {
       targetRepository: taskState.repository,
       captureReport: taskState.evidence_policy.report !== "omit",
     });
-    const prNumber = parsePrNumber(result.prUrl, taskState.repository);
-    $("pull-request").value = String(prNumber);
-    taskState.phase = "pr-created";
-    taskState.pull_request = prNumber;
-    taskState.final_pr_url = result.prUrl;
     taskState.final_task_url = result.taskUrl;
     taskState.final_report = result.report;
-    await saveTaskState();
-    await persist();
+    taskState.pr_discovery = result.discovery;
+
+    if (!result.prUrl) {
+      taskState.phase = "pr-create-uncertain";
+      await saveTaskState();
+      setStatus("Create PR was invoked, but Crossdock has not identified the resulting PR yet. Recovering without invoking Create PR again…");
+      void monitorTask();
+      return;
+    }
+
+    await rememberCreatedPr(result.prUrl);
     await finishInitialAfterPrCreated();
   } catch (error) {
     if (taskState?.phase === "finalizing") {
       taskState.phase = "ready";
       await saveTaskState();
-    } else if (taskState?.phase === "pr-created") {
+    } else if (["pr-create-uncertain", "pr-created"].includes(taskState?.phase)) {
       void monitorTask();
     }
     throw error;
   }
+}
+
+async function recoverInitialPrCreation() {
+  requireTaskState("initial");
+  if (taskState.phase !== "pr-create-uncertain") return false;
+  if (!taskState.pr_discovery || !taskState.final_task_url) throw new Error("created PR recovery state is incomplete");
+  const result = await send({
+    type: "crossdock.recoverCreatedPr",
+    targetRepository: taskState.repository,
+    discovery: taskState.pr_discovery,
+  });
+  if (!result.prUrl) return false;
+  await rememberCreatedPr(result.prUrl);
+  return true;
+}
+
+async function rememberCreatedPr(prUrl) {
+  const prNumber = parsePrNumber(prUrl, taskState.repository);
+  $("pull-request").value = String(prNumber);
+  taskState.phase = "pr-created";
+  taskState.pull_request = prNumber;
+  taskState.final_pr_url = prUrl;
+  await saveTaskState();
+  await persist();
 }
 
 async function finishInitialAfterPrCreated() {


### PR DESCRIPTION
## Summary

- records the target-repository PR URL baseline before invoking the provider's Create PR action
- treats a post-click discovery timeout as `pr-create-uncertain` instead of returning to a state that can click Create PR again
- persists the discovery baseline plus task/report state for restart recovery
- retries discovery by looking only for uniquely new target-repository PR URLs relative to that baseline
- fails closed when recovery yields multiple candidates
- transitions recovered PRs into the existing durable `pr-created` handoff phase

## Validation

CI should run `npm test` and `npm run check` on Node 22. Authenticated live testing remains necessary to validate provider DOM behavior and navigation patterns.