### PR TITLE
docs: reconcile current public status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,41 +2,52 @@
 
 Crossdock is an open-source workflow tool for moving bounded engineering work across conversation, coding-agent execution, and GitHub review without making the developer manually copy state between tools.
 
-> **Status:** early public development. The deterministic GitHub handoff core is being migrated from private incubation; the desktop/mobile application and live browser integration are not yet a supported release.
+> **Status:** early public development. The deterministic handoff core, loopback service, and experimental desktop Chromium browser adapter are public and under test. Crossdock does not yet have a supported end-user desktop/mobile release, and authenticated provider compatibility still requires live validation.
 
 ## What Crossdock is building
 
 The initial route is ChatGPT → Codex Cloud → GitHub. Crossdock keeps that provider integration replaceable where practical rather than making provider names the product model.
 
-A Crossdock task can preserve the exact delegated prompt and complete execution report as one durable task record, create an initial pull request or update an existing PR branch, and independently verify that the durable GitHub handoff exists before reporting completion.
+A completed Crossdock task creates an immutable task record with stable handoff metadata. Prompt and execution-report evidence are independently configurable: current records can retain full canonical evidence, retain only an integrity hash, or omit either evidence class entirely. Crossdock links the record from the initial pull request or a later top-level PR update comment and independently verifies the durable GitHub handoff before reporting completion.
 
-Automation is a choice, not an assumption. The product is being designed to support both automatic handoff and review-before-handoff, plus configurable task-record storage so a public source repository never becomes the accidental destination for private prompts or reports.
+Automation is a choice, not an assumption. The current dashboard supports both automatic handoff and review-before-handoff, plus explicit task-record storage. User-facing configuration is intended to expand rather than force one privacy, retention, storage, or workflow preference on every user.
 
 ## Desktop and mobile
 
 Crossdock targets one task-centric workflow across form factors:
 
-- **Desktop:** a clean workspace with task state, external surfaces, handoff controls, errors, and history visible together where useful.
-- **Mobile:** a focused step flow with compact task state and links/deep links to external surfaces rather than three desktop panes squeezed onto a phone.
+- **Desktop:** a clean workspace with task state, external surfaces, handoff controls, errors, and history visible together where useful. The current experimental implementation uses a Chromium extension plus a loopback Node service; packaging/wrapper architecture remains under evaluation.
+- **Mobile:** a focused step flow with compact task state and links/deep links to external surfaces rather than three desktop panes squeezed onto a phone. The current browser-extension/localhost integration is not a mobile implementation.
 
-Both experiences must expose the same essential state and capabilities while using layouts appropriate to the device.
+Both experiences must expose the same essential state and capabilities while using layouts and integration mechanisms appropriate to the device.
 
 ## Current repository contents
 
-The first public bootstrap migrates the provider-neutral parts of the existing deterministic handoff core and establishes public project documentation. Browser/Codex UI automation will move only after it is separated from Seedbed-private defaults and reviewed for public disclosure.
+The repository currently contains:
+
+- the deterministic task-record and GitHub handoff core;
+- explicit configurable GitHub task-record storage;
+- configurable prompt/report evidence retention;
+- idempotent immutable-record and update-comment retry handling;
+- a loopback HTTP handoff service;
+- an experimental Manifest V3 browser adapter and responsive dashboard;
+- public live-test, architecture, configuration, security, and contribution documentation; and
+- GitHub Actions validation for the Node/JavaScript surfaces.
+
+The browser adapter remains fail-closed and experimental until authenticated live compatibility testing establishes the current provider DOM/control behavior.
 
 ## Documentation
 
-Start with [`docs/README.md`](docs/README.md). The documentation will grow with the implementation and currently covers the workflow model, task records, configuration direction, architecture/security boundaries, and roadmap.
+Start with [`docs/README.md`](docs/README.md). Public testers should use [`docs/testing/public-live-test.md`](docs/testing/public-live-test.md). The documentation covers the workflow model, configurable task evidence, configuration direction, architecture/security boundaries, live-testing expectations, and roadmap.
 
 ## Contributing
 
-Crossdock is intended for public contribution. See [`CONTRIBUTING.md`](CONTRIBUTING.md) and the public issue tracker. UX, graphic design, documentation, accessibility, adapters, packaging, and implementation work are all expected contribution areas.
+Crossdock is intended for public contribution. See [`CONTRIBUTING.md`](CONTRIBUTING.md) and the public issue tracker. UX, graphic design, documentation, accessibility, adapters, packaging, privacy controls, configuration, and implementation work are all expected contribution areas.
 
 ## Security and privacy
 
-Prompts and execution reports may contain private development context. Crossdock source is public; user task records are not therefore public. See [`SECURITY.md`](SECURITY.md) and [`docs/architecture/security-boundaries.md`](docs/architecture/security-boundaries.md).
+Prompts and execution reports may contain private development context. Crossdock source is public; user task records are not therefore public. Users can choose how much prompt/report evidence to retain, and broader transient-data controls are under active design. See [`SECURITY.md`](SECURITY.md), [`docs/architecture/security-boundaries.md`](docs/architecture/security-boundaries.md), and the task-record schema reference.
 
 ## License
 
-Crossdock will use a free/open-source GNU-family copyleft license. Exact GPL-vs-AGPL selection is being finalized before the first public release; no license grant should be inferred until the `LICENSE` file is added.
+Crossdock is free/open-source software licensed under **GNU AGPL-3.0-or-later**. See [`LICENSE`](LICENSE).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Crossdock does not yet have an end-user release. This guide currently covers contributor setup for the migrated handoff core.
+Crossdock does not yet have a supported end-user release. This guide covers contributor setup and points live testers to the current experimental desktop adapter procedure.
 
 ## Requirements
 
@@ -9,7 +9,7 @@ Crossdock does not yet have an end-user release. This guide currently covers con
 
 ## Development
 
-Clone the repository, then run:
+Clone the public repository, then run:
 
 ```text
 npm test
@@ -20,8 +20,24 @@ The current code has no third-party runtime dependencies.
 
 ## What works today
 
-The migrated core can deterministically render task records, reject several known secret-like patterns before GitHub persistence, construct initial PR/update-comment provenance, use an explicitly configured GitHub task-record repository, and verify the durable remote state through its GitHub client abstraction.
+The public implementation can:
+
+- deterministically render immutable task records with independently configurable prompt/report evidence (`full`, `hash`, or `omit`);
+- reject several known secret-like patterns before GitHub-backed plaintext persistence;
+- create and verify initial PR/update-comment provenance;
+- use an explicitly configured GitHub task-record repository;
+- recover exact immutable task records and update comments idempotently after retries;
+- expose a loopback handoff service with browser-origin restrictions; and
+- run an experimental Chromium Manifest V3 adapter/dashboard for ChatGPT → Codex Cloud → GitHub workflows.
+
+The provider adapter intentionally fails closed on ambiguous tabs, controls, repositories, PRs, and recovery states.
+
+## Live testing
+
+Use [`testing/public-live-test.md`](testing/public-live-test.md) for the provider-neutral desktop live-test procedure. That procedure requires an unpacked Chromium-compatible extension, the local Node service, a disposable target repository, and an appropriate private task-record destination.
+
+Syntax/unit/HTTP-boundary CI does not establish authenticated provider compatibility. The live procedure is necessary because provider DOM/control behavior can change independently of Crossdock.
 
 ## What does not exist yet
 
-A supported desktop/mobile UI, installation package, authenticated end-user setup flow, production storage configuration UI, and hardened live ChatGPT/Codex browser adapter are still under development. Track those items in the public issue backlog rather than treating this bootstrap as a release.
+Crossdock does not yet provide a packaged supported desktop application, a mobile implementation, an end-user credential/setup flow, a finalized pluggable storage UI, or a supported compatibility guarantee for the live browser adapter. Those items are tracked publicly rather than implied by the experimental implementation.


### PR DESCRIPTION
## Summary

- updates the root README to reflect the migrated browser adapter, loopback service, configurable evidence, retry hardening, and current experimental status
- records the accepted AGPL-3.0-or-later license instead of the obsolete pending-license text
- points public testers to the provider-neutral live-test guide
- updates getting-started documentation to distinguish what works today from unsupported packaged desktop/mobile releases and provider compatibility guarantees