### PR TITLE
feat: define shared configuration model

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,8 @@ Crossdock is in early public development. These documents describe the intended 
 - [`concepts/workflow.md`](concepts/workflow.md) — task lifecycle from prompt through PR handoff.
 - [`concepts/task-records.md`](concepts/task-records.md) — durable task metadata and configurable evidence retention.
 - [`concepts/adapters.md`](concepts/adapters.md) — provider boundary model.
-- [`configuration/handoff-mode.md`](configuration/handoff-mode.md) — automatic vs review-before-handoff direction.
+- [`configuration/model.md`](configuration/model.md) — shared configuration schema, scopes, precedence, validation, and user-agency semantics.
+- [`configuration/handoff-mode.md`](configuration/handoff-mode.md) — automatic vs review-before-handoff behavior.
 - [`configuration/task-log-storage.md`](configuration/task-log-storage.md) — storage privacy and configuration.
 - [`architecture/overview.md`](architecture/overview.md) — evolving technical architecture.
 - [`architecture/security-boundaries.md`](architecture/security-boundaries.md) — public source, browser sessions, credentials, and task data.

--- a/docs/configuration/model.md
+++ b/docs/configuration/model.md
@@ -1,0 +1,81 @@
+# Configuration Model
+
+Crossdock uses one configuration model across workflow surfaces so desktop, mobile, service, and future clients can resolve the same effective behavior.
+
+Schema identifier: `crossdock.config/v1`.
+
+## Current fields
+
+The initial shared model contains:
+
+- `handoff_mode`: `review` or `automatic`;
+- `evidence_policy.prompt`: `full`, `hash`, or `omit`;
+- `evidence_policy.report`: `full`, `hash`, or `omit`; and
+- `storage`: `null` or a configured storage destination. The first implemented storage kind is `github` with `repository` and `branch`.
+
+The model is intentionally small: a setting should not appear as implemented merely because Product intends to support it later. Additional privacy, lifecycle, provider, storage, and UI settings can extend versioned configuration as their behavior becomes real.
+
+## Precedence
+
+`resolveConfig()` applies layers from least to most specific:
+
+1. built-in defaults;
+2. global user/deployment settings;
+3. provider settings;
+4. workspace settings;
+5. repository settings;
+6. per-task settings.
+
+A more specific layer overrides only the fields it supplies. Partial evidence policy is merged field-by-field, so a repository can change report retention without accidentally changing prompt retention.
+
+A more specific layer can explicitly set `storage: null` to clear an inherited destination. A workflow that requires durable storage must then fail clearly until another valid destination is selected.
+
+Provider limitations and security rules are constraints, not hidden high-priority preference layers: validation should reject an unsupported effective configuration rather than silently overriding the user's visible choice.
+
+## Defaults
+
+The current compatibility defaults are:
+
+```json
+{
+  "schema": "crossdock.config/v1",
+  "handoff_mode": "review",
+  "evidence_policy": {
+    "prompt": "full",
+    "report": "full"
+  },
+  "storage": null
+}
+```
+
+These are implementation defaults, not permanent product policy. User-facing clients should display consequential effective choices before durable persistence or external mutation. Future evidence may justify different defaults without removing supported alternatives.
+
+## Strict validation
+
+Unknown scopes, unknown fields, unsupported enum values, malformed repositories, and unsupported storage kinds fail instead of being ignored. This prevents a misspelled privacy setting from silently falling back to broader retention.
+
+Configuration parsers must not treat an unsupported future option as its nearest current equivalent. Preserve the user's requested value when possible, migrate it explicitly when a defined migration exists, or fail with an actionable explanation.
+
+## Storage normalization
+
+The first storage representation is:
+
+```json
+{
+  "type": "github",
+  "repository": "owner/private-records",
+  "branch": "main"
+}
+```
+
+For compatibility, `type` may be omitted and currently normalizes to `github`. The shared model must not make GitHub storage the permanent architectural boundary; future storage adapters will add explicit kinds and their own validated settings.
+
+## Privacy and user agency
+
+Configuration is the user's statement of desired behavior. Crossdock must not silently retain more evidence, perform more automation, or select a broader data destination than the resolved configuration says.
+
+Durable evidence settings are not a complete data-lifecycle policy. Collection, transient processing, crash recovery, local history, diagnostics, expiration, deletion, encryption, and sharing are separate future configuration areas and must remain distinguishable as they are implemented.
+
+## Effective summary
+
+The core exposes `effectiveConfigSummary()` so user interfaces can show the consequential resolved choices without exposing unrelated internal configuration structure. Desktop and mobile clients should use an equivalent effective-summary concept before a consequential action.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "scripts": {
     "start": "node server.js",
     "test": "node --test",
-    "check": "node --check server.js && node --check src/github-client.js && node --check src/handoff.js && node --check src/http-server.js && node --check src/index.js && node --check src/service.js && node --check src/task-log.js && node --check extension/background.js && node --check extension/content.js && node --check extension/dashboard.js && node --check tests/github-client.test.js && node --check tests/handoff.test.js && node --check tests/http-server.test.js && node --check tests/service.test.js && node --check tests/task-log.test.js"
+    "check": "node --check server.js && node --check src/config.js && node --check src/github-client.js && node --check src/handoff.js && node --check src/http-server.js && node --check src/index.js && node --check src/service.js && node --check src/task-log.js && node --check extension/background.js && node --check extension/content.js && node --check extension/dashboard.js && node --check tests/config.test.js && node --check tests/github-client.test.js && node --check tests/handoff.test.js && node --check tests/http-server.test.js && node --check tests/service.test.js && node --check tests/task-log.test.js"
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,121 @@
+import { EVIDENCE_MODES } from "./task-log.js";
+
+export const CONFIG_SCHEMA = "crossdock.config/v1";
+export const HANDOFF_MODES = Object.freeze(["review", "automatic"]);
+export const CONFIG_SCOPES = Object.freeze(["global", "provider", "workspace", "repository", "task"]);
+
+export const DEFAULT_CONFIG = deepFreeze({
+  schema: CONFIG_SCHEMA,
+  handoff_mode: "review",
+  evidence_policy: { prompt: "full", report: "full" },
+  storage: null,
+});
+
+export function resolveConfig(scopes = {}) {
+  if (!scopes || typeof scopes !== "object" || Array.isArray(scopes)) throw new TypeError("config scopes must be an object");
+  assertKnownKeys(scopes, new Set(CONFIG_SCOPES), "config scopes");
+
+  let resolved = clone(DEFAULT_CONFIG);
+  for (const scope of CONFIG_SCOPES) {
+    const layer = scopes[scope];
+    if (layer == null) continue;
+    resolved = mergeLayer(resolved, normalizeLayer(layer, scope));
+  }
+  return deepFreeze(validateConfig(resolved));
+}
+
+export function validateConfig(config, { requireStorage = false } = {}) {
+  if (!config || typeof config !== "object" || Array.isArray(config)) throw new TypeError("config must be an object");
+  assertKnownKeys(config, new Set(["schema", "handoff_mode", "evidence_policy", "storage"]), "config");
+  if (config.schema !== CONFIG_SCHEMA) throw new Error(`config.schema must be ${CONFIG_SCHEMA}`);
+  if (!HANDOFF_MODES.includes(config.handoff_mode)) throw new Error(`handoff_mode must be one of: ${HANDOFF_MODES.join(", ")}`);
+
+  const evidence = normalizeEvidence(config.evidence_policy, "config.evidence_policy", true);
+  const storage = normalizeStorage(config.storage, "config.storage");
+  if (requireStorage && storage == null) throw new Error("task-record storage must be configured");
+
+  return {
+    schema: CONFIG_SCHEMA,
+    handoff_mode: config.handoff_mode,
+    evidence_policy: evidence,
+    storage,
+  };
+}
+
+export function effectiveConfigSummary(config) {
+  const validated = validateConfig(config);
+  return {
+    handoff_mode: validated.handoff_mode,
+    prompt_evidence: validated.evidence_policy.prompt,
+    report_evidence: validated.evidence_policy.report,
+    storage: validated.storage == null ? null : {
+      type: validated.storage.type,
+      repository: validated.storage.repository,
+      branch: validated.storage.branch,
+    },
+  };
+}
+
+function normalizeLayer(layer, scope) {
+  if (!layer || typeof layer !== "object" || Array.isArray(layer)) throw new TypeError(`${scope} config must be an object`);
+  assertKnownKeys(layer, new Set(["schema", "handoff_mode", "evidence_policy", "storage"]), `${scope} config`);
+  if (layer.schema != null && layer.schema !== CONFIG_SCHEMA) throw new Error(`${scope} config schema must be ${CONFIG_SCHEMA}`);
+
+  const normalized = {};
+  if (Object.hasOwn(layer, "handoff_mode")) {
+    if (!HANDOFF_MODES.includes(layer.handoff_mode)) throw new Error(`${scope}.handoff_mode must be one of: ${HANDOFF_MODES.join(", ")}`);
+    normalized.handoff_mode = layer.handoff_mode;
+  }
+  if (Object.hasOwn(layer, "evidence_policy")) normalized.evidence_policy = normalizeEvidence(layer.evidence_policy, `${scope}.evidence_policy`, false);
+  if (Object.hasOwn(layer, "storage")) normalized.storage = normalizeStorage(layer.storage, `${scope}.storage`);
+  return normalized;
+}
+
+function normalizeEvidence(value, label, requireBoth) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new TypeError(`${label} must be an object`);
+  assertKnownKeys(value, new Set(["prompt", "report"]), label);
+  const result = {};
+  for (const field of ["prompt", "report"]) {
+    if (!Object.hasOwn(value, field)) {
+      if (requireBoth) throw new Error(`${label}.${field} is required`);
+      continue;
+    }
+    if (!EVIDENCE_MODES.includes(value[field])) throw new Error(`${label}.${field} must be one of: ${EVIDENCE_MODES.join(", ")}`);
+    result[field] = value[field];
+  }
+  return result;
+}
+
+function normalizeStorage(value, label) {
+  if (value == null) return null;
+  if (typeof value !== "object" || Array.isArray(value)) throw new TypeError(`${label} must be an object or null`);
+  assertKnownKeys(value, new Set(["type", "repository", "branch"]), label);
+  const type = value.type ?? "github";
+  if (type !== "github") throw new Error(`${label}.type is unsupported: ${type}`);
+  if (typeof value.repository !== "string" || !/^[^/\s]+\/[^/\s]+$/.test(value.repository)) throw new Error(`${label}.repository must be owner/repo`);
+  if (typeof value.branch !== "string" || !value.branch.trim()) throw new Error(`${label}.branch is required`);
+  return { type, repository: value.repository, branch: value.branch };
+}
+
+function mergeLayer(base, layer) {
+  const next = clone(base);
+  if (Object.hasOwn(layer, "handoff_mode")) next.handoff_mode = layer.handoff_mode;
+  if (Object.hasOwn(layer, "evidence_policy")) next.evidence_policy = { ...next.evidence_policy, ...layer.evidence_policy };
+  if (Object.hasOwn(layer, "storage")) next.storage = layer.storage == null ? null : clone(layer.storage);
+  return next;
+}
+
+function assertKnownKeys(value, allowed, label) {
+  for (const key of Object.keys(value)) if (!allowed.has(key)) throw new Error(`${label} contains unknown field: ${key}`);
+}
+
+function clone(value) {
+  return value == null ? value : structuredClone(value);
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const child of Object.values(value)) deepFreeze(child);
+  return value;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+export { CONFIG_SCHEMA, CONFIG_SCOPES, DEFAULT_CONFIG, HANDOFF_MODES, effectiveConfigSummary, resolveConfig, validateConfig } from "./config.js";
 export { GitHubClient } from "./github-client.js";
 export { buildPrBody, buildUpdateComment, persistTaskLog, publishExistingInitialHandoff, publishInitialHandoff, publishUpdateHandoff } from "./handoff.js";
 export { EVIDENCE_MODES, TASK_LOG_SCHEMA, assertGithubSafe, canonicalizeText, evidencePolicy, renderTaskLog, sha256, taskLogPath, validateTaskRecord } from "./task-log.js";

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { CONFIG_SCHEMA, DEFAULT_CONFIG, effectiveConfigSummary, resolveConfig, validateConfig } from "../src/config.js";
+
+test("defaults are explicit and immutable", () => {
+  assert.equal(DEFAULT_CONFIG.schema, CONFIG_SCHEMA);
+  assert.equal(DEFAULT_CONFIG.handoff_mode, "review");
+  assert.deepEqual(DEFAULT_CONFIG.evidence_policy, { prompt: "full", report: "full" });
+  assert.equal(DEFAULT_CONFIG.storage, null);
+  assert.ok(Object.isFrozen(DEFAULT_CONFIG));
+  assert.ok(Object.isFrozen(DEFAULT_CONFIG.evidence_policy));
+});
+
+test("scope precedence is global then provider then workspace then repository then task", () => {
+  const config = resolveConfig({
+    global: { handoff_mode: "automatic", evidence_policy: { prompt: "hash" } },
+    provider: { evidence_policy: { report: "hash" } },
+    workspace: { handoff_mode: "review" },
+    repository: { evidence_policy: { prompt: "omit" }, storage: { repository: "example/records", branch: "main" } },
+    task: { evidence_policy: { report: "omit" }, handoff_mode: "automatic" },
+  });
+  assert.equal(config.handoff_mode, "automatic");
+  assert.deepEqual(config.evidence_policy, { prompt: "omit", report: "omit" });
+  assert.deepEqual(config.storage, { type: "github", repository: "example/records", branch: "main" });
+});
+
+test("higher scope can explicitly clear inherited storage", () => {
+  const config = resolveConfig({
+    global: { storage: { repository: "example/records", branch: "main" } },
+    task: { storage: null },
+  });
+  assert.equal(config.storage, null);
+});
+
+test("partial evidence layers merge without changing unrelated evidence", () => {
+  const config = resolveConfig({ repository: { evidence_policy: { report: "hash" } } });
+  assert.deepEqual(config.evidence_policy, { prompt: "full", report: "hash" });
+});
+
+test("resolved config does not mutate caller layers", () => {
+  const layer = { evidence_policy: { prompt: "omit" }, storage: { repository: "example/records", branch: "main" } };
+  const snapshot = structuredClone(layer);
+  resolveConfig({ task: layer });
+  assert.deepEqual(layer, snapshot);
+});
+
+test("unknown scope and config fields fail instead of being ignored", () => {
+  assert.throws(() => resolveConfig({ mystery: {} }), /unknown field: mystery/);
+  assert.throws(() => resolveConfig({ global: { made_up: true } }), /unknown field: made_up/);
+  assert.throws(() => resolveConfig({ global: { evidence_policy: { unknown: "omit" } } }), /unknown field: unknown/);
+});
+
+test("invalid handoff and evidence modes fail clearly", () => {
+  assert.throws(() => resolveConfig({ task: { handoff_mode: "sometimes" } }), /handoff_mode/);
+  assert.throws(() => resolveConfig({ task: { evidence_policy: { prompt: "sometimes" } } }), /evidence_policy.prompt/);
+});
+
+test("GitHub storage normalizes type and validates destination", () => {
+  const config = resolveConfig({ task: { storage: { repository: "example/private-records", branch: "records/main" } } });
+  assert.deepEqual(config.storage, { type: "github", repository: "example/private-records", branch: "records/main" });
+  assert.throws(() => resolveConfig({ task: { storage: { type: "future", repository: "example/records", branch: "main" } } }), /unsupported/);
+  assert.throws(() => resolveConfig({ task: { storage: { repository: "not-a-repo", branch: "main" } } }), /owner\/repo/);
+});
+
+test("validateConfig can require a durable storage destination", () => {
+  assert.throws(() => validateConfig(DEFAULT_CONFIG, { requireStorage: true }), /storage must be configured/);
+  assert.doesNotThrow(() => validateConfig(resolveConfig({ task: { storage: { repository: "example/records", branch: "main" } } }), { requireStorage: true }));
+});
+
+test("effectiveConfigSummary exposes consequential choices without extra config structure", () => {
+  const config = resolveConfig({
+    task: {
+      handoff_mode: "automatic",
+      evidence_policy: { prompt: "hash", report: "omit" },
+      storage: { repository: "example/private-records", branch: "main" },
+    },
+  });
+  assert.deepEqual(effectiveConfigSummary(config), {
+    handoff_mode: "automatic",
+    prompt_evidence: "hash",
+    report_evidence: "omit",
+    storage: { type: "github", repository: "example/private-records", branch: "main" },
+  });
+});


### PR DESCRIPTION
## Summary

- adds `crossdock.config/v1` as a reusable configuration contract for future desktop/mobile/service clients
- resolves explicit global → provider → workspace → repository → task precedence
- supports current handoff mode, prompt/report evidence, and GitHub storage configuration
- allows more-specific scopes to partially override evidence policy or explicitly clear inherited storage
- rejects unknown fields/scopes and unsupported values rather than silently ignoring privacy/configuration mistakes
- exposes a compact effective-configuration summary for consequential UI review
- documents defaults, precedence, strict validation, storage normalization, and future extensibility

## Validation

Adds focused configuration tests and extends `npm run check` to include the new source/test files.

Relates to #8.