### PR TITLE
feat: add task-record storage adapter boundary

### DIFF
--- a/docs/configuration/task-log-storage.md
+++ b/docs/configuration/task-log-storage.md
@@ -2,13 +2,50 @@
 
 Task records can contain private source context, prompts, and execution reports. Crossdock therefore requires storage to be selected independently from the public application source repository.
 
-The migrated core currently supports a GitHub-backed destination expressed as an explicit repository and branch. It intentionally has no hard-coded public or Seedbed-private default.
+## Adapter boundary
 
-A future configuration layer may support:
+Crossdock now routes task-record persistence through an implementation-level storage adapter contract identified as `crossdock.task-record-storage/v1`.
 
-- a user-selected private GitHub repository;
-- a dedicated private repository configured for Crossdock records;
-- local filesystem storage with a stable linking strategy; and
-- other adapters that preserve immutable addressing, integrity, and access-control semantics.
+A conforming adapter must provide:
 
-A deployment must choose a destination appropriate to the information being persisted. If the destination would expose data beyond its intended confidentiality boundary, persistence should fail closed rather than silently downgrade privacy.
+- `persistImmutable(...)`, returning the exact path/content, a non-empty immutable version identifier, and a durable URL; and
+- `verifyImmutable(...)`, independently re-reading/verifying the expected content for that immutable version.
+
+The handoff core validates the adapter result before it links the record from a pull request. An adapter is therefore responsible for its persistence/addressing mechanics, while Crossdock's handoff layer remains responsible for task-record rendering and PR linkage.
+
+## GitHub adapter
+
+The first implemented adapter is GitHub-backed storage configured with:
+
+```json
+{
+  "type": "github",
+  "repository": "owner/private-records",
+  "branch": "main"
+}
+```
+
+For compatibility, `type` currently defaults to `github` when omitted.
+
+GitHub persistence is create-only. If a retry finds the path already present, Crossdock accepts it only when the existing remote bytes exactly match the expected immutable record, then recovers the commit that introduced/last addressed that path for the durable link. Conflicting content fails closed.
+
+## Future adapters
+
+The adapter boundary is intended to support additional storage without making GitHub repositories the permanent domain model. Candidate backends include:
+
+- a dedicated private record repository;
+- local filesystem or local application storage with a stable linking strategy;
+- encrypted object storage;
+- user-controlled remote stores;
+- split-evidence arrangements where different approved stores hold different evidence classes; and
+- other backends that can satisfy the selected durability/linkage contract.
+
+Serialized `crossdock.config/v1` currently accepts only the implemented `github` storage kind. Unsupported kinds fail instead of silently falling back. A future adapter must be added deliberately to the configuration schema and public documentation before it is presented as supported.
+
+## Privacy and evidence policy
+
+A storage adapter receives an already-rendered task record. It must not silently add prompt/report evidence that the resolved evidence policy omitted or transform a hash-only record into plaintext retention.
+
+A deployment must choose a destination appropriate to the information actually persisted. If the destination would expose data beyond its intended confidentiality boundary, persistence should fail closed rather than silently downgrade privacy.
+
+Durable storage remains distinct from transient browser/application recovery state. Choosing a private task-record adapter does not by itself authorize additional local history, telemetry, or recovery retention.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "scripts": {
     "start": "node server.js",
     "test": "node --test",
-    "check": "node --check server.js && node --check src/config.js && node --check src/github-client.js && node --check src/handoff.js && node --check src/http-server.js && node --check src/index.js && node --check src/service.js && node --check src/task-log.js && node --check extension/background.js && node --check extension/content.js && node --check extension/dashboard.js && node --check tests/config.test.js && node --check tests/github-client.test.js && node --check tests/handoff.test.js && node --check tests/http-server.test.js && node --check tests/service.test.js && node --check tests/task-log.test.js"
+    "check": "node --check server.js && node --check src/config.js && node --check src/github-client.js && node --check src/handoff.js && node --check src/http-server.js && node --check src/index.js && node --check src/service.js && node --check src/storage.js && node --check src/task-log.js && node --check extension/background.js && node --check extension/content.js && node --check extension/dashboard.js && node --check tests/config.test.js && node --check tests/github-client.test.js && node --check tests/handoff.test.js && node --check tests/http-server.test.js && node --check tests/service.test.js && node --check tests/storage.test.js && node --check tests/task-log.test.js"
   }
 }

--- a/src/handoff.js
+++ b/src/handoff.js
@@ -1,3 +1,4 @@
+import { resolveTaskRecordStorage } from "./storage.js";
 import { renderTaskLog, taskLogPath, validateTaskRecord } from "./task-log.js";
 
 export function buildPrBody({ summary, validation = [], issue, logUrl, branch, commit }) {
@@ -19,7 +20,7 @@ export function buildUpdateComment({ summary, validation = [], logUrl, commit })
 }
 
 export async function publishInitialHandoff({ github, storage, task, pr }) {
-  const destination = requireStorage(storage);
+  const destination = resolveTaskRecordStorage({ github, storage });
   validateTaskRecord({ ...task, task_type: "initial", pull_request: null, parent_task_id: null });
   const createdPr = await github.createPullRequest(task.target_repository, {
     title: pr.title,
@@ -37,7 +38,7 @@ export async function publishInitialHandoff({ github, storage, task, pr }) {
 }
 
 export async function publishExistingInitialHandoff({ github, storage, task, pr }) {
-  const destination = requireStorage(storage);
+  const destination = resolveTaskRecordStorage({ github, storage });
   const record = { ...task, task_type: "initial", parent_task_id: null };
   validateTaskRecord(record);
   if (!record.pull_request) throw new Error("existing initial handoff requires pull_request");
@@ -54,12 +55,12 @@ export async function publishExistingInitialHandoff({ github, storage, task, pr 
   await github.updatePullRequest(task.target_repository, record.pull_request, { body });
   const verified = await github.getPullRequest(task.target_repository, record.pull_request);
   if (!verified.body?.includes(persisted.url)) throw new Error("initial handoff verification failed: PR body does not link task record");
-  await verifyTaskLog({ github, storage: destination, path: persisted.path, ref: persisted.commitSha, expectedContent: persisted.content });
+  await destination.verifyImmutable({ path: persisted.path, version: persisted.version, expectedContent: persisted.content });
   return { pullRequest: verified, taskLog: persisted };
 }
 
 export async function publishUpdateHandoff({ github, storage, task, update }) {
-  const destination = requireStorage(storage);
+  const destination = resolveTaskRecordStorage({ github, storage });
   const record = { ...task, task_type: "update" };
   const persisted = await persistTaskLog({ github, storage: destination, record });
   const commentBody = buildUpdateComment({ summary: update.summary, validation: update.validation, logUrl: persisted.url, commit: task.result_commit });
@@ -75,51 +76,22 @@ export async function publishUpdateHandoff({ github, storage, task, update }) {
   const comments = await github.getIssueComments(task.target_repository, task.pull_request);
   const verifiedComment = comments.find((item) => item.id === comment.id && item.body === commentBody);
   if (!verifiedComment) throw new Error("update handoff verification failed: durable PR comment does not match expected task record linkage");
-  await verifyTaskLog({ github, storage: destination, path: persisted.path, ref: persisted.commitSha, expectedContent: persisted.content });
+  await destination.verifyImmutable({ path: persisted.path, version: persisted.version, expectedContent: persisted.content });
   return { comment: verifiedComment, taskLog: persisted };
 }
 
 export async function persistTaskLog({ github, storage, record }) {
-  const destination = requireStorage(storage);
+  const destination = resolveTaskRecordStorage({ github, storage });
   const path = taskLogPath(record);
   const content = renderTaskLog(record);
-
-  try {
-    const response = await github.createFile(destination.repository, path, content, `crossdock: record task ${record.task_id}`, destination.branch);
-    const commitSha = response.commit?.sha;
-    if (!commitSha) throw new Error("task-record persistence did not return a commit SHA");
-    return persistedTaskLog(destination.repository, path, content, commitSha);
-  } catch (error) {
-    if (![409, 422].includes(error?.status)) throw error;
-  }
-
-  const existing = await github.getFile(destination.repository, path, destination.branch);
-  const actual = decodeFileContent(existing, "task-record retry recovery");
-  if (actual !== content) throw new Error("task-record retry conflict: existing immutable record has different content");
-
-  const commit = await github.getLatestCommitForPath(destination.repository, path, destination.branch);
-  return persistedTaskLog(destination.repository, path, content, commit.sha);
-}
-
-function persistedTaskLog(repository, path, content, commitSha) {
-  const url = `https://github.com/${repository}/blob/${commitSha}/${path}`;
-  return { path, content, commitSha, url };
-}
-
-function requireStorage(storage) {
-  if (!storage || typeof storage !== "object") throw new Error("task-record storage must be configured explicitly");
-  if (!/^[^/]+\/[^/]+$/.test(storage.repository ?? "")) throw new Error("storage.repository must be owner/repo");
-  if (typeof storage.branch !== "string" || !storage.branch) throw new Error("storage.branch is required");
-  return storage;
-}
-
-function decodeFileContent(file, context) {
-  if (!file?.sha || typeof file.content !== "string") throw new Error(`${context} failed: remote file missing content`);
-  return Buffer.from(file.content.replace(/\n/g, ""), "base64").toString("utf8");
-}
-
-async function verifyTaskLog({ github, storage, path, ref, expectedContent }) {
-  const file = await github.getFile(storage.repository, path, ref);
-  const actual = decodeFileContent(file, "task-record verification");
-  if (actual !== expectedContent) throw new Error("task-record verification failed: remote content mismatch");
+  const persisted = await destination.persistImmutable({
+    path,
+    content,
+    message: `crossdock: record task ${record.task_id}`,
+  });
+  if (!persisted || typeof persisted !== "object") throw new Error("task-record storage adapter returned no persistence result");
+  if (persisted.path !== path || persisted.content !== content) throw new Error("task-record storage adapter returned inconsistent persistence metadata");
+  if (typeof persisted.version !== "string" || !persisted.version) throw new Error("task-record storage adapter returned no immutable version");
+  if (typeof persisted.url !== "string" || !persisted.url) throw new Error("task-record storage adapter returned no durable URL");
+  return persisted;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 export { CONFIG_SCHEMA, CONFIG_SCOPES, DEFAULT_CONFIG, HANDOFF_MODES, effectiveConfigSummary, resolveConfig, validateConfig } from "./config.js";
 export { GitHubClient } from "./github-client.js";
 export { buildPrBody, buildUpdateComment, persistTaskLog, publishExistingInitialHandoff, publishInitialHandoff, publishUpdateHandoff } from "./handoff.js";
+export { TASK_RECORD_STORAGE_ADAPTER, createGitHubTaskRecordStorage, isTaskRecordStorageAdapter, resolveTaskRecordStorage } from "./storage.js";
 export { EVIDENCE_MODES, TASK_LOG_SCHEMA, assertGithubSafe, canonicalizeText, evidencePolicy, renderTaskLog, sha256, taskLogPath, validateTaskRecord } from "./task-log.js";
 export { createHandoffServer } from "./http-server.js";
 export { dispatchHandoff, hydrateTaskFromPullRequest } from "./service.js";

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,92 @@
+export const TASK_RECORD_STORAGE_ADAPTER = "crossdock.task-record-storage/v1";
+
+export function createGitHubTaskRecordStorage({ github, repository, branch }) {
+  requireGithub(github);
+  if (typeof repository !== "string" || !/^[^/\s]+\/[^/\s]+$/.test(repository)) throw new Error("storage.repository must be owner/repo");
+  if (typeof branch !== "string" || !branch.trim()) throw new Error("storage.branch is required");
+
+  return Object.freeze({
+    adapter: TASK_RECORD_STORAGE_ADAPTER,
+    type: "github",
+    repository,
+    branch,
+
+    async persistImmutable({ path, content, message }) {
+      requireRecordInput(path, content, message);
+      try {
+        const response = await github.createFile(repository, path, content, message, branch);
+        const commitSha = response.commit?.sha;
+        if (!commitSha) throw new Error("task-record persistence did not return a commit SHA");
+        return githubResult({ repository, path, content, commitSha });
+      } catch (error) {
+        if (![409, 422].includes(error?.status)) throw error;
+      }
+
+      const existing = await github.getFile(repository, path, branch);
+      const actual = decodeGitHubFile(existing, "task-record retry recovery");
+      if (actual !== content) throw new Error("task-record retry conflict: existing immutable record has different content");
+
+      const commit = await github.getLatestCommitForPath(repository, path, branch);
+      return githubResult({ repository, path, content, commitSha: commit.sha });
+    },
+
+    async verifyImmutable({ path, version, expectedContent }) {
+      if (typeof version !== "string" || !version) throw new Error("task-record version is required for verification");
+      if (typeof expectedContent !== "string") throw new Error("expected task-record content is required for verification");
+      const file = await github.getFile(repository, path, version);
+      const actual = decodeGitHubFile(file, "task-record verification");
+      if (actual !== expectedContent) throw new Error("task-record verification failed: remote content mismatch");
+      return true;
+    },
+  });
+}
+
+export function resolveTaskRecordStorage({ github, storage }) {
+  if (isTaskRecordStorageAdapter(storage)) return storage;
+  if (!storage || typeof storage !== "object" || Array.isArray(storage)) throw new Error("task-record storage must be configured explicitly");
+  const allowed = new Set(["type", "repository", "branch"]);
+  for (const key of Object.keys(storage)) if (!allowed.has(key)) throw new Error(`storage contains unknown field: ${key}`);
+  const type = storage.type ?? "github";
+  if (type !== "github") throw new Error(`unsupported task-record storage type: ${type}`);
+  return createGitHubTaskRecordStorage({ github, repository: storage.repository, branch: storage.branch });
+}
+
+export function isTaskRecordStorageAdapter(value) {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    value.adapter === TASK_RECORD_STORAGE_ADAPTER &&
+    typeof value.type === "string" &&
+    typeof value.persistImmutable === "function" &&
+    typeof value.verifyImmutable === "function"
+  );
+}
+
+function githubResult({ repository, path, content, commitSha }) {
+  if (typeof commitSha !== "string" || !commitSha) throw new Error("GitHub task-record version is missing");
+  return {
+    path,
+    content,
+    version: commitSha,
+    commitSha,
+    url: `https://github.com/${repository}/blob/${commitSha}/${path}`,
+  };
+}
+
+function requireGithub(github) {
+  if (!github || typeof github !== "object") throw new Error("GitHub client is required for GitHub task-record storage");
+  for (const method of ["createFile", "getFile", "getLatestCommitForPath"]) {
+    if (typeof github[method] !== "function") throw new Error(`GitHub client must implement ${method}()`);
+  }
+}
+
+function requireRecordInput(path, content, message) {
+  if (typeof path !== "string" || !path) throw new Error("task-record path is required");
+  if (typeof content !== "string") throw new Error("task-record content is required");
+  if (typeof message !== "string" || !message) throw new Error("task-record commit message is required");
+}
+
+function decodeGitHubFile(file, context) {
+  if (!file?.sha || typeof file.content !== "string") throw new Error(`${context} failed: remote file missing content`);
+  return Buffer.from(file.content.replace(/\n/g, ""), "base64").toString("utf8");
+}

--- a/src/storage.js
+++ b/src/storage.js
@@ -25,6 +25,7 @@ export function createGitHubTaskRecordStorage({ github, repository, branch }) {
       const existing = await github.getFile(repository, path, branch);
       const actual = decodeGitHubFile(existing, "task-record retry recovery");
       if (actual !== content) throw new Error("task-record retry conflict: existing immutable record has different content");
+      if (typeof github.getLatestCommitForPath !== "function") throw new Error("GitHub client must implement getLatestCommitForPath() for task-record retry recovery");
 
       const commit = await github.getLatestCommitForPath(repository, path, branch);
       return githubResult({ repository, path, content, commitSha: commit.sha });
@@ -75,7 +76,7 @@ function githubResult({ repository, path, content, commitSha }) {
 
 function requireGithub(github) {
   if (!github || typeof github !== "object") throw new Error("GitHub client is required for GitHub task-record storage");
-  for (const method of ["createFile", "getFile", "getLatestCommitForPath"]) {
+  for (const method of ["createFile", "getFile"]) {
     if (typeof github[method] !== "function") throw new Error(`GitHub client must implement ${method}()`);
   }
 }

--- a/tests/handoff.test.js
+++ b/tests/handoff.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { persistTaskLog, publishInitialHandoff, publishUpdateHandoff } from "../src/handoff.js";
+import { TASK_RECORD_STORAGE_ADAPTER } from "../src/storage.js";
 
 const storage = { repository: "example/private-task-records", branch: "main" };
 function task(overrides = {}) { return { task_id: "task-001", created_at: "2026-08-31T20:00:00Z", completed_at: "2026-08-31T20:05:00Z", target_repository: "example/project", base_branch: "main", working_branch: "crossdock/task-001", issue: 123, agent_task_url: "https://example.invalid/tasks/task-001", result_commit: "0123456789abcdef0123456789abcdef01234567", prompt: "Implement the bounded task.", report: "## Summary\n\nImplemented and validated.", ...overrides }; }
@@ -31,6 +32,28 @@ function mockGithub() {
     async getFile(repository, path, ref) { calls.push(["getFile", repository, path, ref]); return { sha: "blob123", content: Buffer.from(storedContent ?? "", "utf8").toString("base64") }; },
     async addIssueComment(repository, number, body) { calls.push(["addIssueComment", repository, number, body]); storedComment = { id: 9, body }; return storedComment; },
     async getIssueComments(repository, number) { calls.push(["getIssueComments", repository, number]); return storedComment ? [storedComment] : []; },
+  };
+}
+
+function memoryStorage() {
+  let stored = null;
+  const calls = [];
+  return {
+    adapter: TASK_RECORD_STORAGE_ADAPTER,
+    type: "memory-test",
+    calls,
+    async persistImmutable({ path, content, message }) {
+      calls.push(["persistImmutable", path, message]);
+      stored = { path, content, version: "memory-v1", url: `memory://records/${encodeURIComponent(path)}` };
+      return stored;
+    },
+    async verifyImmutable({ path, version, expectedContent }) {
+      calls.push(["verifyImmutable", path, version]);
+      assert.equal(path, stored.path);
+      assert.equal(version, stored.version);
+      assert.equal(expectedContent, stored.content);
+      return true;
+    },
   };
 }
 
@@ -98,4 +121,18 @@ test("update retry fails closed on conflicting comment for the same task record"
   github.setStoredCommentBody(`${first.comment.body}\nconflicting edit\n`);
   await assert.rejects(publishUpdateHandoff({ github, storage, task: updateTask, update }), /existing task-record comment has different content/);
   assert.equal(github.calls.filter(([name]) => name === "addIssueComment").length, 1);
+});
+
+test("handoff accepts a conforming non-GitHub task-record storage adapter", async () => {
+  const github = mockGithub();
+  const adapter = memoryStorage();
+  const result = await publishUpdateHandoff({
+    github,
+    storage: adapter,
+    task: task({ task_id: "task-memory", pull_request: 77, parent_task_id: "task-001" }),
+    update: { summary: "Stored outside GitHub.", validation: [] },
+  });
+  assert.match(result.taskLog.url, /^memory:\/\/records\//);
+  assert.deepEqual(adapter.calls.map(([name]) => name), ["persistImmutable", "verifyImmutable"]);
+  assert.ok(!github.calls.some(([name]) => name === "createFile" || name === "getFile"));
 });

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,0 +1,102 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { TASK_RECORD_STORAGE_ADAPTER, createGitHubTaskRecordStorage, isTaskRecordStorageAdapter, resolveTaskRecordStorage } from "../src/storage.js";
+
+function conflict(status = 422) { const error = new Error("exists"); error.status = status; return error; }
+
+function githubMock() {
+  let content = null;
+  let created = false;
+  const calls = [];
+  return {
+    calls,
+    setContent(value) { content = value; created = true; },
+    async createFile(repository, path, value, message, branch) {
+      calls.push(["createFile", repository, path, value, message, branch]);
+      if (created) throw conflict();
+      created = true;
+      content = value;
+      return { commit: { sha: "commit-1" } };
+    },
+    async getFile(repository, path, ref) {
+      calls.push(["getFile", repository, path, ref]);
+      return { sha: "blob-1", content: Buffer.from(content ?? "", "utf8").toString("base64") };
+    },
+    async getLatestCommitForPath(repository, path, ref) {
+      calls.push(["getLatestCommitForPath", repository, path, ref]);
+      return { sha: "commit-1" };
+    },
+  };
+}
+
+test("GitHub storage persists an immutable record and returns stable adapter metadata", async () => {
+  const github = githubMock();
+  const storage = createGitHubTaskRecordStorage({ github, repository: "example/private-records", branch: "main" });
+  assert.ok(isTaskRecordStorageAdapter(storage));
+  const result = await storage.persistImmutable({ path: "crossdock/tasks/task.md", content: "record\n", message: "record task" });
+  assert.deepEqual(result, {
+    path: "crossdock/tasks/task.md",
+    content: "record\n",
+    version: "commit-1",
+    commitSha: "commit-1",
+    url: "https://github.com/example/private-records/blob/commit-1/crossdock/tasks/task.md",
+  });
+  await assert.doesNotReject(storage.verifyImmutable({ path: result.path, version: result.version, expectedContent: result.content }));
+});
+
+test("GitHub storage retry recovers only exact existing content", async () => {
+  const github = githubMock();
+  const storage = createGitHubTaskRecordStorage({ github, repository: "example/private-records", branch: "main" });
+  const first = await storage.persistImmutable({ path: "task.md", content: "same\n", message: "record task" });
+  const second = await storage.persistImmutable({ path: "task.md", content: "same\n", message: "record task" });
+  assert.deepEqual(second, first);
+  assert.equal(github.calls.filter(([name]) => name === "getLatestCommitForPath").length, 1);
+});
+
+test("GitHub storage retry fails closed on conflicting immutable content", async () => {
+  const github = githubMock();
+  const storage = createGitHubTaskRecordStorage({ github, repository: "example/private-records", branch: "main" });
+  await storage.persistImmutable({ path: "task.md", content: "expected\n", message: "record task" });
+  github.setContent("different\n");
+  await assert.rejects(storage.persistImmutable({ path: "task.md", content: "expected\n", message: "record task" }), /different content/);
+});
+
+test("GitHub storage verification fails closed on remote mismatch", async () => {
+  const github = githubMock();
+  const storage = createGitHubTaskRecordStorage({ github, repository: "example/private-records", branch: "main" });
+  const result = await storage.persistImmutable({ path: "task.md", content: "expected\n", message: "record task" });
+  github.setContent("different\n");
+  await assert.rejects(storage.verifyImmutable({ path: result.path, version: result.version, expectedContent: result.content }), /remote content mismatch/);
+});
+
+test("plain GitHub storage configuration resolves to the first adapter", () => {
+  const github = githubMock();
+  const storage = resolveTaskRecordStorage({ github, storage: { repository: "example/private-records", branch: "main" } });
+  assert.equal(storage.type, "github");
+  assert.equal(storage.repository, "example/private-records");
+});
+
+test("an already-instantiated conforming adapter is reused", () => {
+  const adapter = {
+    adapter: TASK_RECORD_STORAGE_ADAPTER,
+    type: "test",
+    async persistImmutable() {},
+    async verifyImmutable() {},
+  };
+  assert.ok(isTaskRecordStorageAdapter(adapter));
+  assert.equal(resolveTaskRecordStorage({ github: null, storage: adapter }), adapter);
+});
+
+test("unsupported serialized storage types fail rather than falling back", () => {
+  assert.throws(
+    () => resolveTaskRecordStorage({ github: githubMock(), storage: { type: "filesystem", repository: "example/records", branch: "main" } }),
+    /unsupported task-record storage type/,
+  );
+});
+
+test("unknown storage fields fail instead of being ignored", () => {
+  assert.throws(
+    () => resolveTaskRecordStorage({ github: githubMock(), storage: { repository: "example/records", branch: "main", accidental: true } }),
+    /unknown field: accidental/,
+  );
+});


### PR DESCRIPTION
## Summary

- introduces `crossdock.task-record-storage/v1` as a storage adapter contract
- moves GitHub immutable persistence/retry verification behind the GitHub storage adapter
- lets handoff code accept either explicit GitHub storage configuration or a compatible adapter
- preserves exact-content retry/idempotency and immutable verification semantics
- adds adapter-focused tests, including a non-GitHub in-memory adapter proving the handoff core no longer fundamentally depends on GitHub as the record store
- updates storage documentation and exports the adapter API

## Validation

CI should run `npm test` and `npm run check` on Node 22.

Relates to #7.