### PR TITLE
docs: track public live compatibility evidence

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Crossdock is in early public development. These documents describe the intended 
 - [`getting-started.md`](getting-started.md) — current development setup and project status.
 - [`testing/README.md`](testing/README.md) — automated vs live validation and reporting guidance.
 - [`testing/public-live-test.md`](testing/public-live-test.md) — provider-neutral desktop live-test steps for public testers.
+- [`testing/compatibility.md`](testing/compatibility.md) — dated public evidence for tested browser/OS/workflow combinations.
 
 ## Concepts
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -25,4 +25,4 @@ Live tests should use disposable target changes and must never publish credentia
 
 Use the public live-test issue template and include the Crossdock ref, operating system, browser/version, Node version, handoff/evidence settings, failing task phase, expected outcome, actual durable GitHub outcome, and redacted screenshots/logs when useful.
 
-Both successes and failures matter. Successful environment reports help establish a compatibility matrix; failures drive adapter hardening.
+Both successes and failures matter. Accepted public results should be summarized in [`compatibility.md`](compatibility.md) with a link to the detailed report. The matrix is dated evidence, not a timeless provider-compatibility promise.

--- a/docs/testing/compatibility.md
+++ b/docs/testing/compatibility.md
@@ -1,0 +1,40 @@
+# Live Compatibility Matrix
+
+Crossdock's browser adapter depends on authenticated provider UI behavior that repository tests cannot prove. This page records **publicly reported, reproducible live-test evidence** without turning anecdotal success into an unsupported compatibility promise.
+
+Use [`public-live-test.md`](public-live-test.md) for the procedure and the repository's live-test issue template for reports.
+
+## Status vocabulary
+
+- **verified** — the listed path completed successfully on the stated Crossdock ref and environment.
+- **failed** — a reproducible failure was reported; link the public issue/report.
+- **partial** — some required steps completed but the full path did not.
+- **not tested** — no public evidence has been recorded.
+
+A previous verification does not guarantee compatibility with a later provider UI. Always include the Crossdock ref and test date.
+
+## Reported environments
+
+| Date | Crossdock ref | OS | Browser | Initial → PR | PR update | Automatic | Evidence modes | Report |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| — | — | — | — | not tested | not tested | not tested | — | — |
+
+Replace the placeholder row when the first public report is accepted. Keep rows concise; detailed reproduction/evidence belongs in the linked issue or comment.
+
+## What counts as a verified path
+
+For **Initial → PR**, the intended PR must exist exactly once, the target change/branch must be correct, the task-record link must be durable, and persisted evidence must match the selected evidence policy.
+
+For **PR update**, the expected existing PR head must change, a new task record must be created, a new top-level update comment must link it, and the original PR body must not be rewritten merely for later provenance.
+
+For **Automatic**, the same durable outcome and safety checks must hold without the manual handoff approval step.
+
+## Privacy
+
+Only record environment and result metadata safe for public disclosure. Never copy private prompt/report plaintext, tokens, cookies, credentials, private source, customer information, or sensitive screenshots into this matrix.
+
+## Maintaining the matrix
+
+A matrix update should link a public test report that contains enough non-secret evidence to understand what was exercised. Conflicting results from the same browser/OS/provider combination should remain visible rather than being averaged away; provider account/workspace variants and UI rollouts may matter.
+
+When a provider UI changes materially, do not erase older rows. Their date and Crossdock ref are useful historical compatibility evidence.


### PR DESCRIPTION
## Summary

- adds a dated public live-compatibility matrix for browser/OS/workflow results
- defines verified/failed/partial/not-tested vocabulary
- defines what counts as a successful initial/update/automatic path
- keeps detailed evidence in linked test reports and private task content out of the matrix
- connects the testing index and documentation index to the matrix

## Goal

Turn public live testing into cumulative compatibility evidence without overclaiming provider support from anecdotal results.