### PR TITLE
docs: define agent capability and review persistence model

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ Crossdock is in early public development. These documents describe the intended 
 
 - [`development/repository-layout.md`](development/repository-layout.md) — source/test/docs organization and ownership boundaries.
 - [`reference/task-record-schema.md`](reference/task-record-schema.md) — current implementation-level task-record schema.
+- [`reference/codex-capabilities.md`](reference/codex-capabilities.md) — dated mapping from current Codex features to Crossdock's provider-neutral capability model.
 - [`roadmap.md`](roadmap.md) — public development sequence.
 
 For contribution workflow and code-quality expectations, see [`../CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Crossdock is in early public development. These documents describe the intended 
 - [`concepts/workflow.md`](concepts/workflow.md) — task lifecycle from prompt through PR handoff.
 - [`concepts/task-records.md`](concepts/task-records.md) — durable task metadata and configurable evidence retention.
 - [`concepts/adapters.md`](concepts/adapters.md) — provider boundary model.
+- [`concepts/agent-capabilities.md`](concepts/agent-capabilities.md) — provider-neutral work-item intents, first-class code review, persistence, and capability-advertising model.
 
 ## Configuration
 

--- a/docs/concepts/agent-capabilities.md
+++ b/docs/concepts/agent-capabilities.md
@@ -1,0 +1,105 @@
+# Agent Capabilities
+
+Crossdock should coordinate more than implementation tasks without turning any one coding-agent product surface into the Crossdock domain model.
+
+The core abstraction is a **work item**: a bounded request delegated to an agent, with explicit intent, target, evidence policy, lifecycle state, durable result linkage, and optional ancestry to earlier work.
+
+## Work-item intents
+
+The initial intent set is:
+
+- `implement` — produce or update code and usually a branch or pull request;
+- `review` — inspect an existing change and produce review findings without treating the review itself as implementation;
+- `investigate` — analyze a defect, CI failure, architecture question, or repository state and produce findings/recommendations;
+- `triage` — classify, prioritize, or route issues/work without necessarily changing code;
+- `remediate` — address a known finding, review comment, security issue, CI failure, or other identified defect;
+- `verify` — independently check a claimed result, fix, release candidate, or compatibility state;
+- `scheduled` — repeat another supported intent according to user-approved scheduling semantics;
+- `parallel-family` — coordinate multiple related work items whose executions are intentionally independent or concurrent.
+
+These names describe user intent. A provider adapter may expose only a subset.
+
+## Provider capabilities
+
+Adapters should advertise capabilities rather than forcing Crossdock to infer them from product names or UI controls. A capability description can state whether an adapter supports, for example:
+
+- implementation tasks;
+- pull-request review;
+- review guidance/focus;
+- follow-up fixes from review findings;
+- parallel task execution;
+- local/CLI execution;
+- cloud execution;
+- scheduled execution;
+- image or screenshot inputs;
+- security-specific analysis;
+- branch or pull-request creation/update;
+- result/report retrieval; and
+- supported durable identifiers or URLs.
+
+Unsupported combinations should fail explicitly before delegation.
+
+## Review is a first-class work item
+
+A code review is not merely a comment attached to an implementation task. It has its own request, execution, result, evidence policy, and lineage.
+
+A review work item should be able to persist:
+
+- the exact review request or its selected evidence representation;
+- repository and pull-request identity;
+- reviewed commit/head SHA;
+- optional review focus such as correctness, security, compatibility, performance, tests, accessibility, or architecture;
+- provider task/review identifier;
+- completion time and outcome;
+- complete review report or configured hash/omission representation;
+- durable GitHub review/comment/thread identifiers when applicable; and
+- ancestry to the implementation or earlier review that caused it.
+
+The immutable record should make it possible to answer: **what was reviewed, at which commit, with what instructions, what did the agent report, and what durable GitHub artifact corresponds to that execution?**
+
+A review result never becomes human merge approval merely because it found no issues.
+
+## Review → fix → re-review lineage
+
+Crossdock should preserve a chain such as:
+
+```text
+implementation work item
+  -> review work item
+      -> finding(s)
+          -> remediation work item
+              -> re-review work item
+```
+
+Each execution remains immutable. Later work references earlier work rather than rewriting its record.
+
+A finding may be represented by a durable GitHub review thread/comment, a structured finding identifier in a review report, or both. Crossdock should not invent thread identity when the provider/GitHub surface cannot prove it.
+
+## Persistence model
+
+The existing `crossdock.task-record/v2` schema is intentionally implementation-oriented: `task_type` currently distinguishes only initial and update handoffs. Expanding Crossdock to review/investigation/remediation should not overload those two values with unrelated meanings.
+
+Before implementation, define a compatible successor record model that separates at least:
+
+- work-item `intent` from Git/PR handoff phase;
+- parent/causal lineage from branch-update ancestry;
+- result evidence from provider-specific durable artifacts; and
+- reviewed/target commit identity from a resulting implementation commit.
+
+Existing v1/v2 records remain immutable and readable under their historical meaning.
+
+## Human authority
+
+Crossdock can request, persist, and surface agent review. It must not silently:
+
+- approve a pull request on behalf of a human;
+- merge because an agent review is clean;
+- resolve human-authored review threads without explicit authority;
+- convert an agent finding into a fact without preserving the underlying evidence; or
+- allow retries to duplicate equivalent durable reviews/comments when the provider supports stable identity.
+
+## Codex mapping
+
+Codex currently maps naturally onto several of these capabilities. Its GitHub integration can review pull requests automatically or through `@codex review`, and review guidance can focus the analysis. Codex can also act on review feedback in the same PR context. Crossdock should expose those behaviors through the generic `review` and `remediate` intents rather than making `@codex review` itself a core concept.
+
+Codex also supports broader engineering work such as implementation, repository questions/investigation, parallel agent work, reusable Skills, and multiple execution surfaces. Those capabilities should be added only where Crossdock contributes durable coordination, state, evidence, or cross-surface handoff rather than duplicating Codex UI for its own sake.

--- a/docs/concepts/agent-capabilities.md
+++ b/docs/concepts/agent-capabilities.md
@@ -2,7 +2,7 @@
 
 Crossdock should coordinate more than implementation tasks without turning any one coding-agent product surface into the Crossdock domain model.
 
-The core abstraction is a **work item**: a bounded request delegated to an agent, with explicit intent, target, evidence policy, lifecycle state, durable result linkage, and optional ancestry to earlier work.
+The core abstraction is a **work item**: one bounded request delegated to an agent, with explicit intent, target, evidence policy, lifecycle state, durable result linkage, and optional ancestry to earlier work.
 
 ## Work-item intents
 
@@ -12,12 +12,12 @@ The initial intent set is:
 - `review` — inspect an existing change and produce review findings without treating the review itself as implementation;
 - `investigate` — analyze a defect, CI failure, architecture question, or repository state and produce findings/recommendations;
 - `triage` — classify, prioritize, or route issues/work without necessarily changing code;
-- `remediate` — address a known finding, review comment, security issue, CI failure, or other identified defect;
-- `verify` — independently check a claimed result, fix, release candidate, or compatibility state;
-- `scheduled` — repeat another supported intent according to user-approved scheduling semantics;
-- `parallel-family` — coordinate multiple related work items whose executions are intentionally independent or concurrent.
+- `remediate` — address a known finding, review comment, security issue, CI failure, or other identified defect; and
+- `verify` — independently check a claimed result, fix, release candidate, or compatibility state.
 
 These names describe user intent. A provider adapter may expose only a subset.
+
+Scheduling and parallelism are deliberately **not** intents. A scheduled review is still a `review` work item with recurrence/execution-policy metadata. A parallel family is a coordinator/group that contains multiple independently executed work items; each child keeps its own intent, execution identity, result, evidence policy, and immutable record.
 
 ## Provider capabilities
 
@@ -41,7 +41,7 @@ Unsupported combinations should fail explicitly before delegation.
 
 ## Review is a first-class work item
 
-A code review is not merely a comment attached to an implementation task. It has its own request, execution, result, evidence policy, and lineage.
+A code review is not merely a comment attached to an implementation task. It has its own request, execution, result, evidence policy, publication policy, and lineage.
 
 A review work item should be able to persist:
 
@@ -52,12 +52,42 @@ A review work item should be able to persist:
 - provider task/review identifier;
 - completion time and outcome;
 - complete review report or configured hash/omission representation;
-- durable GitHub review/comment/thread identifiers when applicable; and
+- zero or more typed durable-artifact references produced by the execution; and
 - ancestry to the implementation or earlier review that caused it.
 
-The immutable record should make it possible to answer: **what was reviewed, at which commit, with what instructions, what did the agent report, and what durable GitHub artifact corresponds to that execution?**
+The immutable record should make it possible to answer: **what was reviewed, at which commit, with what instructions, what did the agent report, and which durable artifacts—if any—were proven to correspond to that execution?**
 
 A review result never becomes human merge approval merely because it found no issues.
+
+## Publication is separate from retained review evidence
+
+Task-record/result retention and external publication are different data flows and must have different authorization.
+
+For example, `report: hash` or `report: omit` controls what Crossdock retains in its durable record. It does **not** imply permission to post full review text into a GitHub review, PR comment, another source-control system, chat, or other external destination.
+
+Every externally published artifact should therefore carry or resolve an explicit publication decision that identifies at least:
+
+- artifact type;
+- destination/provider;
+- target identity;
+- expected visibility/classification when knowable;
+- payload/evidence class being published; and
+- user/deployment authority for the mutation.
+
+A provider adapter must fail before publication when the effective policy does not authorize the payload/destination combination. Crossdock should never infer publication permission merely because equivalent text was available transiently or retained somewhere else.
+
+## Typed durable artifacts
+
+The core provenance contract uses generic typed durable-artifact references rather than GitHub-specific fields. An artifact reference should identify, where supported:
+
+- adapter/provider and artifact type;
+- stable remote identifier;
+- durable URL or fetch locator;
+- target repository/workspace identity;
+- published payload classification/evidence mode when relevant; and
+- verification state or version/commit identity when the remote system exposes one.
+
+The GitHub adapter can map review IDs, PR comments, review threads, pull requests, commits, and other GitHub-native objects into this contract. Another source-control or review adapter can provide equivalent native artifacts without pretending they are GitHub objects.
 
 ## Review → fix → re-review lineage
 
@@ -73,7 +103,15 @@ implementation work item
 
 Each execution remains immutable. Later work references earlier work rather than rewriting its record.
 
-A finding may be represented by a durable GitHub review thread/comment, a structured finding identifier in a review report, or both. Crossdock should not invent thread identity when the provider/GitHub surface cannot prove it.
+A finding may be represented by a typed durable review-thread/comment artifact, a structured finding identifier in a review report, or both. Crossdock should not invent artifact or thread identity when the remote/provider surface cannot prove it.
+
+## Retry and ambiguous remote state
+
+Durable external mutations need the same fail-closed retry semantics as current task-record and PR-linkage handoffs.
+
+Where possible, Crossdock should include a stable Crossdock idempotency marker or other provider-supported correlation value that can be searched/reconciled remotely after a timeout. A retry may reuse a remote artifact only when equivalence can be proven.
+
+If a review/comment/publication might already have succeeded but Crossdock cannot recover a stable remote identity or otherwise prove equivalence, the work item enters an **ambiguous recovery state**. Crossdock must not blindly repeat the mutation and risk duplicate reviews/comments simply because the provider lacks a convenient stable identifier.
 
 ## Persistence model
 
@@ -82,8 +120,11 @@ The existing `crossdock.task-record/v2` schema is intentionally implementation-o
 Before implementation, define a compatible successor record model that separates at least:
 
 - work-item `intent` from Git/PR handoff phase;
+- execution policy (including scheduling) from intent;
+- family/group membership from individual execution identity;
 - parent/causal lineage from branch-update ancestry;
-- result evidence from provider-specific durable artifacts; and
+- retained result evidence from external publication policy;
+- generic typed durable artifacts from provider-specific identifiers; and
 - reviewed/target commit identity from a resulting implementation commit.
 
 Existing v1/v2 records remain immutable and readable under their historical meaning.
@@ -95,11 +136,12 @@ Crossdock can request, persist, and surface agent review. It must not silently:
 - approve a pull request on behalf of a human;
 - merge because an agent review is clean;
 - resolve human-authored review threads without explicit authority;
-- convert an agent finding into a fact without preserving the underlying evidence; or
-- allow retries to duplicate equivalent durable reviews/comments when the provider supports stable identity.
+- convert an agent finding into a fact without preserving the underlying evidence;
+- publish full review content merely because the durable record retained or processed it; or
+- repeat an external review/comment mutation when prior remote success cannot be ruled out.
 
 ## Codex mapping
 
 Codex currently maps naturally onto several of these capabilities. Its GitHub integration can review pull requests automatically or through `@codex review`, and review guidance can focus the analysis. Codex can also act on review feedback in the same PR context. Crossdock should expose those behaviors through the generic `review` and `remediate` intents rather than making `@codex review` itself a core concept.
 
-Codex also supports broader engineering work such as implementation, repository questions/investigation, parallel agent work, reusable Skills, and multiple execution surfaces. Those capabilities should be added only where Crossdock contributes durable coordination, state, evidence, or cross-surface handoff rather than duplicating Codex UI for its own sake.
+Codex also supports broader engineering work such as implementation, repository questions/investigation, parallel agent work, reusable Skills, and multiple execution surfaces. Scheduling and parallelism remain execution-policy/grouping concerns around those underlying intents. Those capabilities should be added only where Crossdock contributes durable coordination, state, evidence, or cross-surface handoff rather than duplicating Codex UI for its own sake.

--- a/docs/reference/codex-capabilities.md
+++ b/docs/reference/codex-capabilities.md
@@ -1,0 +1,55 @@
+# Codex Capability Mapping
+
+This document records the current Codex surface that is relevant to Crossdock's adapter design. It is a compatibility/reference document, not the Crossdock domain model.
+
+Last reviewed: 2026-08-31.
+
+Provider capabilities change independently of Crossdock. Live adapter claims still require current compatibility evidence.
+
+## Current relevant capabilities
+
+| Crossdock intent/capability | Current Codex surface | Crossdock direction |
+| --- | --- | --- |
+| `implement` | Cloud/software-engineering tasks can write code, run tests, and propose pull requests. | Already the first live adapter path. Keep task execution provider-neutral. |
+| `review` | GitHub PR review can run automatically for ready PRs or via `@codex review`; review guidance can narrow focus. | Make review a first-class work item with reviewed SHA and durable review evidence. |
+| `remediate` | Codex review threads can be followed by instructions to implement suggested changes. | Preserve review → finding → remediation lineage rather than treating the fix as an unrelated task. |
+| `investigate` | Codex can answer repository questions, debug issues, run commands/tests, and analyze code. | Persist bounded investigations when durable findings/provenance add value. |
+| parallel work | Codex supports multiple agents/tasks in parallel; the app supports isolated worktrees. | Model related executions as a task family only when Crossdock needs coordination/history. |
+| reusable workflows | Codex Skills provide reusable instructions/workflows. | Prefer referencing/using provider capability rather than cloning a second Crossdock skill system. |
+| local execution | Codex is available through CLI/editor/app surfaces in addition to cloud execution. | Add adapters when local execution materially improves privacy, recovery, or workflow portability. |
+| security analysis | Codex Security can identify/validate findings and propose patches for human review. | Treat security analysis/remediation as explicit capabilities with stronger evidence/authority boundaries. |
+| delegated conversation | Codex can be invoked from surfaces such as Slack in supported configurations. | Integrate only where Crossdock adds durable cross-surface state/provenance; do not mirror every delegation UI. |
+
+## Code review details
+
+Codex PR review is particularly relevant because it already has durable GitHub artifacts. Crossdock should be able to initiate or observe a review, persist the review execution record, identify the reviewed commit, and link the resulting GitHub review/comments without claiming that an AI review is a human approval.
+
+Review guidance should remain data, not a new intent for every focus. Examples include correctness, security, compatibility, tests, performance, accessibility, architecture, or dependency freshness.
+
+When a review produces findings and a later Codex execution fixes them, Crossdock should preserve the causal chain and then permit a re-review against the new head SHA.
+
+## What Crossdock should not duplicate
+
+Crossdock should generally leave these provider-native concerns to Codex unless cross-surface coordination requires otherwise:
+
+- model selection and internal reasoning controls;
+- worktree implementation details;
+- provider-native task/thread UI;
+- provider-native Skills authoring/execution mechanics;
+- provider account/workspace administration;
+- security scanner internals;
+- every provider-specific button or command as a core Crossdock concept.
+
+The Crossdock value is durable orchestration: intent, state, target identity, evidence policy, provenance, retries, cross-surface linkage, verification, and recovery.
+
+## Sources
+
+Official references used for this mapping:
+
+- OpenAI, “Introducing upgrades to Codex” — PR review, review guidance, and follow-up fixes.
+- OpenAI, “Introducing the Codex app” — parallel agents, worktrees, and Skills.
+- OpenAI, “Codex” — CLI/editor/ChatGPT surfaces and code-review positioning.
+- OpenAI Help Center, “Codex Security” — validated security findings and proposed patches for human review.
+- OpenAI, “Codex is now generally available” — Slack delegation and broader workflow surface.
+
+Because provider behavior changes, these references do not replace Crossdock's dated live compatibility matrix.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,7 +14,19 @@ Crossdock is pre-release. The current public sequence is intentionally capabilit
 - pluggable task-record storage;
 - automatic and review-before-handoff state machine;
 - task history/recovery semantics;
-- provider adapter contracts.
+- provider adapter contracts;
+- provider-neutral work-item intents and capability discovery;
+- successor durable-record semantics that can represent review, investigation, remediation, and verification without overloading implementation-only task types.
+
+## Agent workflows
+
+- first-class persisted code-review work items;
+- review focus/guidance, reviewed-commit identity, and durable review/comment/thread linkage;
+- review finding → remediation → re-review lineage;
+- investigation/CI-diagnosis and remediation workflows;
+- parallel task families where providers support independent concurrent work;
+- scheduled/repeatable agent work where Crossdock contributes durable state and provenance;
+- image/screenshot-assisted and security-specific workflows only through explicit advertised adapter capabilities.
 
 ## User experience
 
@@ -29,7 +41,8 @@ Crossdock is pre-release. The current public sequence is intentionally capabilit
 - browser extension/service boundary;
 - ChatGPT/Codex live adapter compatibility;
 - GitHub authentication and least-privilege setup;
-- compatibility fixtures and provider-change recovery.
+- compatibility fixtures and provider-change recovery;
+- prefer supported provider APIs/SDKs where available while retaining isolated fail-closed browser adapters for unsupported boundaries.
 
 ## Distribution
 


### PR DESCRIPTION
## Summary

- defines a provider-neutral work-item abstraction instead of treating every agent feature as an implementation task
- establishes first-class intents for implement, review, investigate, triage, remediate, verify, scheduled work, and parallel task families
- defines code review as its own persisted work item with reviewed SHA, request/focus, report evidence, durable GitHub artifact identity, and lineage
- defines review → finding → remediation → re-review ancestry
- separates Crossdock core concepts from Codex-specific invocation details
- records the need for a successor record schema instead of overloading `task_type: initial|update`
- adds a dated Codex capability mapping covering review, remediation, investigation, parallel work/worktrees, Skills, local/cloud surfaces, security analysis, and delegated surfaces
- updates the public roadmap to include persisted review and broader agent workflows

## Why

Users should be able to use Crossdock to execute and persist code reviews and other agent work with the same durable provenance guarantees as implementation tasks, without turning Codex product features into Crossdock's domain model.

## Validation

Documentation-only architecture/concept change; CI should still pass repository checks.

Related: #29, #30, #37, #38.