### PR TITLE
docs: propose task-record v3 for review and agent work

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,8 @@ Crossdock is in early public development. These documents describe the intended 
 ## Development and reference
 
 - [`development/repository-layout.md`](development/repository-layout.md) — source/test/docs organization and ownership boundaries.
-- [`reference/task-record-schema.md`](reference/task-record-schema.md) — current implementation-level task-record schema.
+- [`reference/task-record-schema.md`](reference/task-record-schema.md) — current implemented task-record v2 schema.
+- [`reference/task-record-v3-proposal.md`](reference/task-record-v3-proposal.md) — proposed successor schema for review, remediation, verification, scheduling, families, publication policy, and typed durable artifacts.
 - [`reference/codex-capabilities.md`](reference/codex-capabilities.md) — dated mapping from current Codex features to Crossdock's provider-neutral capability model.
 - [`roadmap.md`](roadmap.md) — public development sequence.
 

--- a/docs/reference/task-record-v3-proposal.md
+++ b/docs/reference/task-record-v3-proposal.md
@@ -12,44 +12,67 @@ The proposed successor identifier is:
 crossdock.task-record/v3
 ```
 
-A review, investigation, or remediation is still a bounded delegated task. Keeping the established `task-record` name avoids an unnecessary public vocabulary and path migration while version 3 changes the record semantics explicitly.
-
-Existing v1/v2 records remain immutable and are never rewritten into v3.
+A review, investigation, or remediation is still a bounded delegated task. Existing v1/v2 records remain immutable and are never rewritten into v3.
 
 ## Design goals
 
-Version 3 must answer, for any one agent execution:
+Version 3 must answer, for one agent execution:
 
-1. What bounded work was requested?
-2. What was the intent of that work?
-3. What exact target state was acted on or inspected?
-4. Which adapter/provider execution performed it?
-5. What result did that execution produce under the selected evidence policy?
-6. What later durable artifacts were published or linked, under what publication authority?
-7. How was each durable artifact remotely verified?
-8. What earlier task caused this task, and what family/schedule does it belong to?
-9. If a remote mutation became ambiguous, what state prevents an unsafe duplicate retry?
+1. What bounded work was requested and with what intent?
+2. What globally unambiguous repository/change/commit state was inspected or changed?
+3. Which agent adapter/provider execution performed it?
+4. What result was retained under the selected evidence policy?
+5. What external publication was requested, forbidden, attempted, completed, or left ambiguous?
+6. What remotely addressable artifacts were created or linked, and how were they verified?
+7. What earlier task or durable finding caused this task?
+8. What schedule occurrence or parallel family does it belong to without collapsing independent executions?
+9. If a remote mutation became ambiguous, what prevents an unsafe duplicate retry?
 
 ## Orthogonal concepts
 
 Version 3 keeps these concepts independent:
 
 - **intent** — `implement`, `review`, `investigate`, `triage`, `remediate`, or `verify`;
-- **handoff phase** — Git/source-control state such as initial PR creation, branch update, review publication, or no source-control mutation;
-- **execution policy** — ordinary one-shot execution or a scheduled occurrence;
+- **source target** — source-control adapter, host, repository identity, refs, PR/change identity, and exact commit state;
+- **handoff phase** — source-control state such as initial PR creation, branch update, review publication, or no source-control mutation;
+- **execution policy** — ordinary one-shot execution or one occurrence of a schedule;
 - **family membership** — optional grouping for related/parallel tasks;
-- **lineage** — causal parent task or finding;
+- **lineage** — causal parent task and, only when durably resolvable, a causal finding artifact;
 - **retention evidence policy** — what Crossdock stores in this immutable record;
-- **publication policy/outcome** — what Crossdock was authorized to publish to each external destination;
-- **durable artifacts** — remotely addressable objects created or linked by the execution/handoff.
+- **publication decisions** — independent authorization and outcome for each external payload/destination;
+- **durable artifacts** — externally addressable objects created or linked by the execution/handoff.
 
 Scheduling and parallelism are not intents. Every scheduled occurrence and every parallel child has its own task ID and immutable record.
 
+## Proposed deterministic structure
+
+Version 3 remains one UTF-8/LF Markdown file, but metadata and arbitrary evidence must not share an ambiguous Markdown-heading grammar.
+
+The file has:
+
+1. deterministic YAML front matter containing all machine-readable metadata, including publication decisions and durable-artifact references; then
+2. zero, one, or two **byte-length-delimited** plaintext evidence payloads for Request and Result when their mode is `full`.
+
+A parser consumes each payload by its declared UTF-8 byte length. It must never scan evidence text for headings or sentinels. This means a review request/result may itself contain `## Artifact 1`, YAML, fenced code, or any other text without changing parse boundaries.
+
+Conceptual framing:
+
+```text
+---
+<deterministic YAML metadata>
+---
+
+X-Crossdock-Evidence: request; bytes=123
+<exactly 123 UTF-8 bytes>
+X-Crossdock-Evidence: result; bytes=456
+<exactly 456 UTF-8 bytes>
+```
+
+The exact framing syntax is still proposal-level; golden parser/renderer fixtures must freeze it before v3 ships. Byte count, not a terminator string, defines each evidence boundary.
+
 ## Proposed front matter
 
-Version 3 remains a Markdown record with deterministic YAML front matter and Markdown evidence sections.
-
-Core scalar fields:
+Representative fields:
 
 ```yaml
 schema: "crossdock.task-record/v3"
@@ -61,15 +84,18 @@ completed_at: "2026-09-01T00:05:00Z"
 
 handoff_phase: "review-publication"
 parent_task_id: "crossdock-previous"
-parent_finding_id: null
+causal_artifact: null
 family_id: null
 schedule_id: null
 schedule_occurrence: null
 
+source_adapter: "github"
+source_host: "github.com"
 target_repository: "owner/repo"
 target_pull_request: 42
-target_ref: "feature/example"
-target_commit: "<reviewed head sha>"
+base_ref: "main"
+working_ref: "feature/example"
+target_commit: "<reviewed or pre-change sha>"
 result_commit: null
 
 agent_adapter: "codex-github-review"
@@ -81,138 +107,153 @@ request_evidence: "full"
 result_evidence: "full"
 request_sha256: "..."
 result_sha256: "..."
+request_bytes: 123
+result_bytes: 456
 
-artifact_count: 2
+publication_count: 1
+artifact_count: 1
 recovery_state: "clear"
 ```
 
-`target_commit` is the state inspected or acted on. `result_commit` is a new implementation state produced by the task when one exists. A code review normally has a `target_commit` and no `result_commit`; remediation normally has both.
+`source_adapter` and `source_host` qualify the repository independently of the agent adapter. `owner/repo` alone is not globally unique across GitHub.com, GitHub Enterprise hosts, or other forges.
 
-`handoff_phase` is intentionally separate from `intent`. An implementation task can create an initial PR or update an existing branch; a review can publish a review, persist privately without publication, or attach only a durable reference.
+`base_ref` and `working_ref` remain separate so v3 does not lose provenance already present in v2 initial handoffs. Either may be null only when it has no meaning for the intent/target.
 
-## Evidence sections
+`target_commit` is the exact state inspected or acted on. `result_commit` is a new implementation state produced by the task when one exists. A review normally has `target_commit` and no `result_commit`; remediation that changes code normally has both.
 
-Version 3 generalizes v2's prompt/report wording to **Request** and **Result** while preserving the same evidence modes:
+## Retained evidence
 
-- `full` — canonical plaintext plus SHA-256 digest;
-- `hash` — digest only;
-- `omit` — neither plaintext nor digest.
+Version 3 generalizes v2's prompt/report wording to **Request** and **Result** while preserving the same modes:
 
-When `request_evidence: full`:
+- `full` — canonical plaintext plus SHA-256 digest and byte length;
+- `hash` — digest only; no plaintext payload and byte length is null;
+- `omit` — neither plaintext nor digest; byte length is null.
 
-```markdown
-## Request
+The digest is over the complete canonical UTF-8/LF evidence text. `hash` and `omit` never grant permission to publish plaintext elsewhere.
 
-Review this pull request for correctness and compatibility.
-```
+## Publication decisions are independent records of authority and outcome
 
-When `result_evidence: full`:
+Publication metadata must exist even when no external artifact was created. A private review therefore remains auditable without inventing an artifact.
 
-```markdown
-## Result
+Each publication decision is a structured front-matter entry with at least:
 
-### Findings
-...
-```
-
-The digest is always over the canonical UTF-8/LF representation of the corresponding complete text. `hash` and `omit` never imply that Crossdock is authorized to publish plaintext to another system.
-
-## Durable artifact sections
-
-Each externally addressable artifact is represented by a numbered, machine-readable metadata section. The first implementation may encode these fields as deterministic YAML-like key/value blocks inside Markdown; the parser/writer tests must define the exact grammar before v3 ships.
-
-Conceptual example:
-
-```markdown
-## Artifact 1
-
-- type: source-control.review
-- adapter: github
-- id: 123456
-- url: https://github.com/owner/repo/pull/42#pullrequestreview-123456
-- target: owner/repo#42
-- version: <reviewed head sha>
-- visibility: public
-- published_evidence: full
-- publication_authority: explicit-user
-- verification: verified
-
-## Artifact 2
-
-- type: crossdock.task-record
-- adapter: github-task-record-storage
-- id: <immutable commit/path identity>
-- url: https://github.com/.../blob/<sha>/...
-- visibility: private
-- published_evidence: full
-- publication_authority: configured-storage
-- verification: verified
-```
-
-Core artifact types are namespaced rather than GitHub-specific. A GitHub adapter maps review IDs, PR comments, review threads, PRs, commits, and similar objects into generic typed references. Other providers use their own adapters without inventing GitHub fields.
-
-### Artifact publication metadata
-
-For every external mutation, the record must truthfully preserve enough information to establish:
-
-- destination/provider adapter;
-- durable target identity;
-- payload/evidence class actually published;
+- stable Crossdock publication ID/correlation marker;
+- destination adapter and host;
+- target identity;
+- payload class: `request`, `result`, `summary`, `finding`, or another versioned class;
+- representation: `full`, `hash`, `omit`, or another explicitly supported publication representation;
 - expected visibility/classification when knowable;
-- authority that permitted the publication; and
-- remote verification outcome.
+- authority source;
+- requested state: `forbidden`, `not-requested`, or `authorized`;
+- outcome: `not-attempted`, `published`, `failed`, or `ambiguous`;
+- durable artifact reference when publication produced one and identity was reconciled.
 
-A durable artifact identifier alone is insufficient because publication is a separate data flow from record retention.
+Conceptual YAML:
+
+```yaml
+publications:
+  - publication_id: "pub-review-result"
+    destination_adapter: "github"
+    destination_host: "github.com"
+    target: "owner/repo#42"
+    payload_class: "result"
+    representation: "full"
+    visibility: "public"
+    authority: "explicit-user"
+    requested: "authorized"
+    outcome: "published"
+    artifact_id: "artifact-review-1"
+```
+
+A scalar such as `published_evidence: full` is insufficient because it cannot say *which* evidence class was published. An adapter must never infer permission to publish Request text merely because Result publication was authorized.
+
+For `forbidden` or `not-requested`, `artifact_id` is null and no mutation is allowed. `authorized + not-attempted` may permit a later attempt according to workflow state. `ambiguous` prohibits blind retry until remote equivalence is reconciled.
+
+## Durable artifacts
+
+Durable artifacts are typed references stored structurally in front matter, not Markdown sections. Core fields are provider-neutral; adapters map provider-specific IDs into them.
+
+Conceptual YAML:
+
+```yaml
+artifacts:
+  - artifact_id: "artifact-review-1"
+    type: "source-control.review"
+    adapter: "github"
+    host: "github.com"
+    remote_id: "123456"
+    url: "https://github.com/owner/repo/pull/42#pullrequestreview-123456"
+    target: "owner/repo#42"
+    version: "<reviewed head sha>"
+    verification: "verified"
+```
+
+The task record **must not contain a durable artifact entry for itself** when that entry depends on the record's own storage commit/hash/URL. That would be self-referential: writing the final identity into the bytes would change the identity being described.
+
+Task-record storage identity and post-write verification belong to the storage/handoff result or a separately persisted verification envelope/index. The immutable task record describes the delegated execution and external artifacts whose identity exists independently before record bytes are finalized.
 
 ## Review example
 
-A review task should have approximately:
+A review task should include approximately:
 
 ```yaml
 intent: "review"
 handoff_phase: "review-publication"
+source_adapter: "github"
+source_host: "github.com"
 target_repository: "owner/repo"
 target_pull_request: 42
+base_ref: "main"
+working_ref: "feature/example"
 target_commit: "abc123..."
 result_commit: null
 parent_task_id: "implementation-task-id"
+causal_artifact: null
 ```
 
-The Request contains the exact review instructions and optional guidance. The Result contains the complete review report according to the selected retention policy. Typed artifacts link the resulting source-control review/comments/threads where the adapter can prove their identity.
+Request contains the review instructions under its selected retention mode. Result contains the review report under its selected retention mode. Publication decisions independently say whether any Result, summary, or finding may be sent to the source-control review surface.
 
-A review with no findings still records what was reviewed and what the agent reported. It does not encode human approval or merge authority.
+A clean agent review never becomes human approval or merge authority.
 
-## Remediation example
+## Findings and remediation lineage
 
-A remediation task caused by a review finding should have approximately:
+Crossdock must not invent a free-form `parent_finding_id` that cannot be resolved later.
+
+A remediation may point to:
+
+1. the parent review task alone; or
+2. a **typed durable finding artifact** referenced by `causal_artifact` when the parent execution/provider/source-control surface produced a stable, remotely or durably resolvable finding/thread identity.
+
+If Result evidence is `hash`/`omit` and no durable finding artifact exists, the remediation may truthfully say it descends from the review task, but it must not claim a more specific finding identity.
+
+Example:
 
 ```yaml
 intent: "remediate"
-handoff_phase: "branch-update"
 parent_task_id: "review-task-id"
-parent_finding_id: "finding-2"
+causal_artifact: "artifact-review-thread-2"
 target_commit: "abc123..."
 result_commit: "def456..."
 ```
 
-The Result describes the remediation and validation. A later re-review is a new `review` task whose `parent_task_id` points to the remediation task and whose `target_commit` is `def456...`.
+A later re-review is a new `review` task whose parent is the remediation and whose `target_commit` is `def456...`.
 
 ## Investigation and verification
 
-An `investigate` task may have no external mutation and therefore `artifact_count: 1` only for its immutable task record, or additional artifacts if findings are published elsewhere.
+An `investigate` task may have no publication decisions beyond explicitly recorded `not-requested`/`forbidden` policy and may produce no external durable artifacts.
 
-A `verify` task identifies the exact target state being checked. Its result is verification evidence, not an implementation result unless the task also produced a change—in which case that should normally be a separate remediation/implementation task rather than silently mixing intents.
+A `verify` task identifies the exact target state being checked. Its result is verification evidence, not an implementation result. If a fix is produced, model the fix as a separate remediation/implementation execution rather than silently mixing intents.
 
 ## Scheduled occurrences
 
-A schedule is a coordinator/policy outside one execution record. Each run receives a new `task_id` and may include:
+A schedule is coordinator/policy state outside one execution record. Each occurrence receives a new `task_id` and may include:
 
 ```yaml
 schedule_id: "nightly-review"
 schedule_occurrence: "2026-09-01T02:00:00Z"
 ```
 
-The task's intent remains `review`, `verify`, `investigate`, or another supported intent. Retries of the *same occurrence* must preserve idempotency semantics rather than creating an indistinguishable second occurrence record.
+The intent remains `review`, `verify`, `investigate`, or another supported intent. Retrying the same occurrence must preserve idempotency and correlation rather than create an indistinguishable second occurrence.
 
 ## Parallel families
 
@@ -222,47 +263,54 @@ A family groups related work without collapsing executions:
 family_id: "crossdock-family-..."
 ```
 
-Each child has its own task ID, intent, target, agent execution, result, artifacts, and record. The family coordinator may maintain separate transient/UI state but must not replace child provenance.
+Each child has its own task ID, intent, target, agent execution, result, publication decisions, artifacts, and record.
 
-## Recovery state and idempotency
+## Recovery and idempotency
 
-`recovery_state` begins as `clear` and may only be written as completed after required remote verification succeeds.
+`recovery_state` describes whether all required remote mutations were reconciled for this completed record.
 
-If an external mutation may have succeeded but Crossdock cannot reconcile a stable remote artifact identity, the task must enter an **ambiguous** operational recovery state and must not blindly repeat that mutation. A final completed record should describe the reconciled durable outcome; abandoned/failed execution-state persistence is a separate lifecycle design and must not fabricate completed provenance.
+Each external publication/mutation should carry a stable Crossdock correlation marker when the destination allows one. If a mutation may have succeeded but Crossdock cannot prove whether the intended remote artifact exists, its publication outcome becomes `ambiguous` and the workflow must stop rather than repeat the mutation.
 
-Adapters should use a stable Crossdock task/artifact correlation marker where the remote system allows one. Retrying an operation may reuse an existing artifact only when equivalence is provable.
+Only after reconciliation may an ambiguous outcome become `published` or `failed`. A completed record must never claim `verified` for an artifact whose identity remains ambiguous.
+
+Operational state for an unfinished/ambiguous execution may need a separate recoverable state document; it must not fabricate a completed immutable task record.
 
 ## Validation invariants
 
 A v3 writer/parser must enforce at least:
 
 1. `schema` is exactly `crossdock.task-record/v3`.
-2. `task_id`, intent, timestamps, adapter/provider/surface, and target identity required by the intent are valid and non-empty.
-3. `intent` is a supported v3 vocabulary value; scheduling/family values are never accepted as intents.
-4. `review` requires an exact `target_commit`; if a PR is the review target, `target_pull_request` is required.
-5. `review` does not imply or encode human approval.
-6. `remediate` identifies the target state and resulting commit when code changed.
-7. Evidence modes and hashes obey the same canonicalization/truthfulness rules as v2.
-8. `artifact_count` exactly matches parsed artifact sections.
-9. Every published artifact records publication authority and verification state.
-10. Artifact types/identifiers are provider-neutral at the core boundary and adapter-specific only within typed metadata.
-11. `hash`/`omit` retained evidence never grants plaintext publication authority.
-12. A completed record never claims an external artifact was verified when reconciliation was ambiguous.
-13. Scheduling and family membership never collapse multiple executions into one task record.
-14. Existing v1/v2 paths/content are never mutated as part of v3 migration.
-15. Secret/classification preflight remains destination-adapter-specific and occurs before mutation.
+2. `task_id`, intent, timestamps, agent adapter/provider/surface, and intent-required target fields are valid and non-empty.
+3. Source repository identity includes source adapter and host; `owner/repo` alone is insufficient.
+4. `base_ref` and `working_ref` remain independent fields and are required when the handoff semantics require them.
+5. `intent` is a supported v3 intent; scheduling/family values are never accepted as intents.
+6. `review` requires an exact `target_commit`; PR review requires a target PR/change identity.
+7. `review` never encodes human approval or merge authority.
+8. `remediate` identifies target state and resulting commit when code changed.
+9. Evidence modes, hashes, byte lengths, and presence/absence of payloads obey deterministic canonicalization rules.
+10. Evidence parsing is byte-length-delimited; arbitrary evidence text can never be parsed as metadata.
+11. `publication_count` and `artifact_count` match their structured front-matter collections.
+12. Every publication states payload class, representation, authority, requested state, and outcome independently of artifact creation.
+13. `hash`/`omit` retained evidence never grants plaintext publication authority.
+14. Durable artifact types are provider-neutral at the core boundary; provider-specific IDs remain adapter metadata.
+15. The task record never embeds a self-referential final storage identity that cannot exist before its bytes are committed.
+16. A specific causal finding is accepted only when it resolves to a durable typed artifact; otherwise lineage stops at the parent task.
+17. A completed record never claims a remote artifact was verified while publication identity is ambiguous.
+18. Scheduling and family membership never collapse multiple executions into one task record.
+19. Existing v1/v2 paths/content are never mutated as part of v3 migration.
+20. Destination-specific secret/classification preflight occurs before every external mutation.
 
 ## Path compatibility
 
-Proposed path remains:
+For repository-scoped work, the proposed path remains:
 
 ```text
 crossdock/tasks/<target-owner>/<target-repo>/<yyyy>/<mm>/<task-id>.md
 ```
 
-The schema identifier, not a path rename, distinguishes v3. Keeping the established path avoids needless storage migration and allows one immutable history containing multiple schema generations.
+The record itself carries `source_adapter` and `source_host`, so identical repository slugs on different forges remain distinguishable even if a configured store uses the same path convention. A future multi-forge storage layout may add host/adapter path namespaces; that is a storage-addressing concern and must not rewrite existing records.
 
-For work with no source repository, a future target namespace must be designed explicitly rather than inserting fake repository names. The first v3 implementation should remain repository-scoped.
+For work with no source repository, a future target namespace must be designed explicitly rather than inserting fake repository names. The first v3 implementation remains repository-scoped.
 
 ## Migration
 
@@ -276,13 +324,14 @@ There is no in-place migration.
 
 ## Implementation sequence
 
-1. Finalize the exact deterministic artifact-section grammar and vocabulary.
-2. Add v3 parser/renderer validation tests and golden fixtures.
-3. Add typed artifact and publication-policy domain helpers.
-4. Add review-specific target/result validation.
-5. Extend storage/handoff code without changing v1/v2 readers.
+1. Freeze the exact deterministic YAML subset and byte-length evidence framing with golden fixtures.
+2. Implement v3 parser/renderer validation without changing the active v2 writer.
+3. Add source-target, publication-decision, typed-artifact, and lineage domain helpers.
+4. Add review-specific target/result validation and publication preflight.
+5. Extend storage/handoff code while preserving v1/v2 readers and immutable historical content.
 6. Implement one review path end-to-end behind an experimental capability flag.
-7. Perform live review → remediation → re-review validation against disposable public PRs.
-8. Promote adapter capability status only after dated compatibility evidence exists.
+7. Add remediation and re-review lineage using durable typed finding artifacts where available.
+8. Perform live review → remediation → re-review validation against disposable public PRs.
+9. Promote adapter capability status only after dated compatibility evidence exists.
 
 Related: #29, #30, #37, #38.

--- a/docs/reference/task-record-v3-proposal.md
+++ b/docs/reference/task-record-v3-proposal.md
@@ -1,0 +1,288 @@
+# Task Record v3 Proposal
+
+Status: **design proposal; not yet emitted by Crossdock**.
+
+This proposal extends Crossdock's durable execution record so code reviews, investigations, remediations, verifications, scheduled occurrences, and parallel task families can use the same provenance system as implementation work without changing the historical meaning of `crossdock.task-record/v1` or `/v2`.
+
+## Decision: keep the `task-record` name
+
+The proposed successor identifier is:
+
+```text
+crossdock.task-record/v3
+```
+
+A review, investigation, or remediation is still a bounded delegated task. Keeping the established `task-record` name avoids an unnecessary public vocabulary and path migration while version 3 changes the record semantics explicitly.
+
+Existing v1/v2 records remain immutable and are never rewritten into v3.
+
+## Design goals
+
+Version 3 must answer, for any one agent execution:
+
+1. What bounded work was requested?
+2. What was the intent of that work?
+3. What exact target state was acted on or inspected?
+4. Which adapter/provider execution performed it?
+5. What result did that execution produce under the selected evidence policy?
+6. What later durable artifacts were published or linked, under what publication authority?
+7. How was each durable artifact remotely verified?
+8. What earlier task caused this task, and what family/schedule does it belong to?
+9. If a remote mutation became ambiguous, what state prevents an unsafe duplicate retry?
+
+## Orthogonal concepts
+
+Version 3 keeps these concepts independent:
+
+- **intent** — `implement`, `review`, `investigate`, `triage`, `remediate`, or `verify`;
+- **handoff phase** — Git/source-control state such as initial PR creation, branch update, review publication, or no source-control mutation;
+- **execution policy** — ordinary one-shot execution or a scheduled occurrence;
+- **family membership** — optional grouping for related/parallel tasks;
+- **lineage** — causal parent task or finding;
+- **retention evidence policy** — what Crossdock stores in this immutable record;
+- **publication policy/outcome** — what Crossdock was authorized to publish to each external destination;
+- **durable artifacts** — remotely addressable objects created or linked by the execution/handoff.
+
+Scheduling and parallelism are not intents. Every scheduled occurrence and every parallel child has its own task ID and immutable record.
+
+## Proposed front matter
+
+Version 3 remains a Markdown record with deterministic YAML front matter and Markdown evidence sections.
+
+Core scalar fields:
+
+```yaml
+schema: "crossdock.task-record/v3"
+task_id: "crossdock-..."
+intent: "review"
+status: "completed"
+created_at: "2026-09-01T00:00:00Z"
+completed_at: "2026-09-01T00:05:00Z"
+
+handoff_phase: "review-publication"
+parent_task_id: "crossdock-previous"
+parent_finding_id: null
+family_id: null
+schedule_id: null
+schedule_occurrence: null
+
+target_repository: "owner/repo"
+target_pull_request: 42
+target_ref: "feature/example"
+target_commit: "<reviewed head sha>"
+result_commit: null
+
+agent_adapter: "codex-github-review"
+agent_provider: "codex"
+agent_surface: "github-review"
+agent_task_url: "https://..."
+
+request_evidence: "full"
+result_evidence: "full"
+request_sha256: "..."
+result_sha256: "..."
+
+artifact_count: 2
+recovery_state: "clear"
+```
+
+`target_commit` is the state inspected or acted on. `result_commit` is a new implementation state produced by the task when one exists. A code review normally has a `target_commit` and no `result_commit`; remediation normally has both.
+
+`handoff_phase` is intentionally separate from `intent`. An implementation task can create an initial PR or update an existing branch; a review can publish a review, persist privately without publication, or attach only a durable reference.
+
+## Evidence sections
+
+Version 3 generalizes v2's prompt/report wording to **Request** and **Result** while preserving the same evidence modes:
+
+- `full` — canonical plaintext plus SHA-256 digest;
+- `hash` — digest only;
+- `omit` — neither plaintext nor digest.
+
+When `request_evidence: full`:
+
+```markdown
+## Request
+
+Review this pull request for correctness and compatibility.
+```
+
+When `result_evidence: full`:
+
+```markdown
+## Result
+
+### Findings
+...
+```
+
+The digest is always over the canonical UTF-8/LF representation of the corresponding complete text. `hash` and `omit` never imply that Crossdock is authorized to publish plaintext to another system.
+
+## Durable artifact sections
+
+Each externally addressable artifact is represented by a numbered, machine-readable metadata section. The first implementation may encode these fields as deterministic YAML-like key/value blocks inside Markdown; the parser/writer tests must define the exact grammar before v3 ships.
+
+Conceptual example:
+
+```markdown
+## Artifact 1
+
+- type: source-control.review
+- adapter: github
+- id: 123456
+- url: https://github.com/owner/repo/pull/42#pullrequestreview-123456
+- target: owner/repo#42
+- version: <reviewed head sha>
+- visibility: public
+- published_evidence: full
+- publication_authority: explicit-user
+- verification: verified
+
+## Artifact 2
+
+- type: crossdock.task-record
+- adapter: github-task-record-storage
+- id: <immutable commit/path identity>
+- url: https://github.com/.../blob/<sha>/...
+- visibility: private
+- published_evidence: full
+- publication_authority: configured-storage
+- verification: verified
+```
+
+Core artifact types are namespaced rather than GitHub-specific. A GitHub adapter maps review IDs, PR comments, review threads, PRs, commits, and similar objects into generic typed references. Other providers use their own adapters without inventing GitHub fields.
+
+### Artifact publication metadata
+
+For every external mutation, the record must truthfully preserve enough information to establish:
+
+- destination/provider adapter;
+- durable target identity;
+- payload/evidence class actually published;
+- expected visibility/classification when knowable;
+- authority that permitted the publication; and
+- remote verification outcome.
+
+A durable artifact identifier alone is insufficient because publication is a separate data flow from record retention.
+
+## Review example
+
+A review task should have approximately:
+
+```yaml
+intent: "review"
+handoff_phase: "review-publication"
+target_repository: "owner/repo"
+target_pull_request: 42
+target_commit: "abc123..."
+result_commit: null
+parent_task_id: "implementation-task-id"
+```
+
+The Request contains the exact review instructions and optional guidance. The Result contains the complete review report according to the selected retention policy. Typed artifacts link the resulting source-control review/comments/threads where the adapter can prove their identity.
+
+A review with no findings still records what was reviewed and what the agent reported. It does not encode human approval or merge authority.
+
+## Remediation example
+
+A remediation task caused by a review finding should have approximately:
+
+```yaml
+intent: "remediate"
+handoff_phase: "branch-update"
+parent_task_id: "review-task-id"
+parent_finding_id: "finding-2"
+target_commit: "abc123..."
+result_commit: "def456..."
+```
+
+The Result describes the remediation and validation. A later re-review is a new `review` task whose `parent_task_id` points to the remediation task and whose `target_commit` is `def456...`.
+
+## Investigation and verification
+
+An `investigate` task may have no external mutation and therefore `artifact_count: 1` only for its immutable task record, or additional artifacts if findings are published elsewhere.
+
+A `verify` task identifies the exact target state being checked. Its result is verification evidence, not an implementation result unless the task also produced a change—in which case that should normally be a separate remediation/implementation task rather than silently mixing intents.
+
+## Scheduled occurrences
+
+A schedule is a coordinator/policy outside one execution record. Each run receives a new `task_id` and may include:
+
+```yaml
+schedule_id: "nightly-review"
+schedule_occurrence: "2026-09-01T02:00:00Z"
+```
+
+The task's intent remains `review`, `verify`, `investigate`, or another supported intent. Retries of the *same occurrence* must preserve idempotency semantics rather than creating an indistinguishable second occurrence record.
+
+## Parallel families
+
+A family groups related work without collapsing executions:
+
+```yaml
+family_id: "crossdock-family-..."
+```
+
+Each child has its own task ID, intent, target, agent execution, result, artifacts, and record. The family coordinator may maintain separate transient/UI state but must not replace child provenance.
+
+## Recovery state and idempotency
+
+`recovery_state` begins as `clear` and may only be written as completed after required remote verification succeeds.
+
+If an external mutation may have succeeded but Crossdock cannot reconcile a stable remote artifact identity, the task must enter an **ambiguous** operational recovery state and must not blindly repeat that mutation. A final completed record should describe the reconciled durable outcome; abandoned/failed execution-state persistence is a separate lifecycle design and must not fabricate completed provenance.
+
+Adapters should use a stable Crossdock task/artifact correlation marker where the remote system allows one. Retrying an operation may reuse an existing artifact only when equivalence is provable.
+
+## Validation invariants
+
+A v3 writer/parser must enforce at least:
+
+1. `schema` is exactly `crossdock.task-record/v3`.
+2. `task_id`, intent, timestamps, adapter/provider/surface, and target identity required by the intent are valid and non-empty.
+3. `intent` is a supported v3 vocabulary value; scheduling/family values are never accepted as intents.
+4. `review` requires an exact `target_commit`; if a PR is the review target, `target_pull_request` is required.
+5. `review` does not imply or encode human approval.
+6. `remediate` identifies the target state and resulting commit when code changed.
+7. Evidence modes and hashes obey the same canonicalization/truthfulness rules as v2.
+8. `artifact_count` exactly matches parsed artifact sections.
+9. Every published artifact records publication authority and verification state.
+10. Artifact types/identifiers are provider-neutral at the core boundary and adapter-specific only within typed metadata.
+11. `hash`/`omit` retained evidence never grants plaintext publication authority.
+12. A completed record never claims an external artifact was verified when reconciliation was ambiguous.
+13. Scheduling and family membership never collapse multiple executions into one task record.
+14. Existing v1/v2 paths/content are never mutated as part of v3 migration.
+15. Secret/classification preflight remains destination-adapter-specific and occurs before mutation.
+
+## Path compatibility
+
+Proposed path remains:
+
+```text
+crossdock/tasks/<target-owner>/<target-repo>/<yyyy>/<mm>/<task-id>.md
+```
+
+The schema identifier, not a path rename, distinguishes v3. Keeping the established path avoids needless storage migration and allows one immutable history containing multiple schema generations.
+
+For work with no source repository, a future target namespace must be designed explicitly rather than inserting fake repository names. The first v3 implementation should remain repository-scoped.
+
+## Migration
+
+There is no in-place migration.
+
+- v1 readers keep v1 semantics.
+- v2 readers keep v2 semantics.
+- v3-aware readers may read all three versions through version-specific parsers.
+- the writer switches to v3 only after parser/renderer, storage, handoff, and compatibility tests are complete.
+- historical task records remain byte-for-byte unchanged.
+
+## Implementation sequence
+
+1. Finalize the exact deterministic artifact-section grammar and vocabulary.
+2. Add v3 parser/renderer validation tests and golden fixtures.
+3. Add typed artifact and publication-policy domain helpers.
+4. Add review-specific target/result validation.
+5. Extend storage/handoff code without changing v1/v2 readers.
+6. Implement one review path end-to-end behind an experimental capability flag.
+7. Perform live review → remediation → re-review validation against disposable public PRs.
+8. Promote adapter capability status only after dated compatibility evidence exists.
+
+Related: #29, #30, #37, #38.

--- a/docs/reference/task-record-v3-proposal.md
+++ b/docs/reference/task-record-v3-proposal.md
@@ -16,30 +16,33 @@ A review, investigation, or remediation is still a bounded delegated task. Exist
 
 ## Design goals
 
-Version 3 must answer, for one agent execution:
+Version 3 must answer, for one completed agent execution:
 
 1. What bounded work was requested and with what intent?
-2. What globally unambiguous repository/change/commit state was inspected or changed?
-3. Which agent adapter/provider execution performed it?
-4. What result was retained under the selected evidence policy?
-5. What external publication was requested, forbidden, attempted, completed, or left ambiguous?
-6. What remotely addressable artifacts were created or linked, and how were they verified?
-7. What earlier task or durable finding caused this task?
-8. What schedule occurrence or parallel family does it belong to without collapsing independent executions?
-9. If a remote mutation became ambiguous, what prevents an unsafe duplicate retry?
+2. What globally unambiguous source repository/change/version was inspected or changed?
+3. What originating issue/work item, if any, caused the request?
+4. Which agent adapter/provider execution performed it?
+5. What result was retained under the selected evidence policy?
+6. What external publication was forbidden, not requested, authorized and completed, or terminally failed?
+7. What remotely addressable artifacts were created or linked, and how were they verified?
+8. What earlier immutable task record or durable finding caused this task?
+9. What schedule occurrence or parallel family does it belong to without collapsing independent executions?
+
+Ambiguous in-flight remote state is deliberately **not** encoded as a completed v3 task record. It belongs to recoverable operational state until reconciled.
 
 ## Orthogonal concepts
 
 Version 3 keeps these concepts independent:
 
 - **intent** — `implement`, `review`, `investigate`, `triage`, `remediate`, or `verify`;
-- **source target** — source-control adapter, host, repository identity, refs, PR/change identity, and exact commit state;
-- **handoff phase** — source-control state such as initial PR creation, branch update, review publication, or no source-control mutation;
+- **source target** — source-control adapter, host, opaque native repository/change identities, refs, and exact version state;
+- **origin** — optional provider-neutral issue/work-item identity that caused the delegated work;
+- **handoff phase** — source-control state such as initial change creation, branch update, review publication, or no source-control mutation;
 - **execution policy** — ordinary one-shot execution or one occurrence of a schedule;
 - **family membership** — optional grouping for related/parallel tasks;
-- **lineage** — causal parent task and, only when durably resolvable, a causal finding artifact;
+- **lineage** — causal parent task plus a durable locator for its already-finalized record and, only when resolvable, a causal finding artifact within that parent context;
 - **retention evidence policy** — what Crossdock stores in this immutable record;
-- **publication decisions** — independent authorization and outcome for each external payload/destination;
+- **publication decisions** — independent authorization and terminal outcome for each external payload/destination;
 - **durable artifacts** — externally addressable objects created or linked by the execution/handoff.
 
 Scheduling and parallelism are not intents. Every scheduled occurrence and every parallel child has its own task ID and immutable record.
@@ -50,29 +53,28 @@ Version 3 remains one UTF-8/LF Markdown file, but metadata and arbitrary evidenc
 
 The file has:
 
-1. deterministic YAML front matter containing all machine-readable metadata, including publication decisions and durable-artifact references; then
+1. deterministic YAML front matter containing all machine-readable metadata, including source/origin identity, lineage, publication decisions, and durable-artifact references; then
 2. zero, one, or two **byte-length-delimited** plaintext evidence payloads for Request and Result when their mode is `full`.
 
-A parser consumes each payload by its declared UTF-8 byte length. It must never scan evidence text for headings or sentinels. This means a review request/result may itself contain `## Artifact 1`, YAML, fenced code, or any other text without changing parse boundaries.
+A parser consumes each payload by its declared UTF-8 byte length. It must never scan evidence text for headings or sentinels. A review request/result may itself contain YAML, `## Artifact 1`, fenced code, or arbitrary Unicode without changing parse boundaries.
 
 Conceptual framing:
 
 ```text
 ---
-<deterministic YAML metadata>
+<deterministic metadata>
 ---
-
 X-Crossdock-Evidence: request; bytes=123
 <exactly 123 UTF-8 bytes>
 X-Crossdock-Evidence: result; bytes=456
 <exactly 456 UTF-8 bytes>
 ```
 
-The exact framing syntax is still proposal-level; golden parser/renderer fixtures must freeze it before v3 ships. Byte count, not a terminator string, defines each evidence boundary.
+The experimental codec may use canonical JSON-compatible YAML (JSON is a YAML 1.2 subset) to freeze one deterministic metadata grammar without adding a YAML dependency. Golden parser/renderer fixtures must freeze the exact wire representation before production v3 writing is enabled.
 
-## Proposed front matter
+## Proposed metadata
 
-Representative fields:
+Representative conceptual fields:
 
 ```yaml
 schema: "crossdock.task-record/v3"
@@ -83,43 +85,70 @@ created_at: "2026-09-01T00:00:00Z"
 completed_at: "2026-09-01T00:05:00Z"
 
 handoff_phase: "review-publication"
-parent_task_id: "crossdock-previous"
-causal_artifact: null
 family_id: null
 schedule_id: null
 schedule_occurrence: null
 
-source_adapter: "github"
-source_host: "github.com"
-target_repository: "owner/repo"
-target_pull_request: 42
-base_ref: "main"
-working_ref: "feature/example"
-target_commit: "<reviewed or pre-change sha>"
-result_commit: null
+source:
+  adapter: "github"
+  host: "github.com"
+  repository_id: "owner/repo"
+  change_id: "42"
+  base_ref: "main"
+  working_ref: "feature/example"
+  target_version: "<reviewed or pre-change sha>"
+  result_version: null
 
-agent_adapter: "codex-github-review"
-agent_provider: "codex"
-agent_surface: "github-review"
-agent_task_url: "https://..."
+origin:
+  adapter: "github"
+  host: "github.com"
+  type: "issue"
+  id: "17"
+  url: "https://github.com/owner/repo/issues/17"
 
-request_evidence: "full"
-result_evidence: "full"
-request_sha256: "..."
-result_sha256: "..."
-request_bytes: 123
-result_bytes: 456
+parent_task_id: "crossdock-previous"
+parent_record:
+  storage_adapter: "github-task-record-storage"
+  locator: "owner/private-records:crossdock/tasks/.../crossdock-previous.md"
+  version: "<immutable storage version>"
+  sha256: "<digest of exact parent-record bytes>"
+causal_artifact: null
 
-publication_count: 1
-artifact_count: 1
+agent:
+  adapter: "codex-github-review"
+  provider: "codex"
+  surface: "github-review"
+  task_url: "https://..."
+
+evidence:
+  request: { mode: "full", sha256: "...", bytes: 123 }
+  result: { mode: "full", sha256: "...", bytes: 456 }
+
+publications: []
+artifacts: []
 recovery_state: "clear"
 ```
 
-`source_adapter` and `source_host` qualify the repository independently of the agent adapter. `owner/repo` alone is not globally unique across GitHub.com, GitHub Enterprise hosts, or other forges.
+### Opaque source identity
 
-`base_ref` and `working_ref` remain separate so v3 does not lose provenance already present in v2 initial handoffs. Either may be null only when it has no meaning for the intent/target.
+The v3 core does not define repository slugs or numeric pull-request IDs. `source.repository_id` and optional `source.change_id` are **opaque native identifiers interpreted by the named source adapter**.
 
-`target_commit` is the exact state inspected or acted on. `result_commit` is a new implementation state produced by the task when one exists. A review normally has `target_commit` and no `result_commit`; remediation that changes code normally has both.
+For GitHub.com an adapter may map:
+
+- repository ID: `owner/repo`;
+- change ID: `42` for pull request 42.
+
+Another forge may use hierarchical, UUID, URI-like, or otherwise native identifiers without inventing a GitHub-shaped convention. `source.adapter` and `source.host` qualify those opaque values.
+
+`base_ref` and `working_ref` remain separate so v3 does not lose provenance already present in v2 initial handoffs. `target_version` is the exact source state inspected/acted on; `result_version` is a new state produced by the execution when one exists.
+
+## Originating issue/work item
+
+Version 2 persists an optional `issue`. Version 3 preserves and generalizes that provenance through optional `origin` metadata rather than a GitHub-only numeric field.
+
+An origin contains at least adapter, host, type, opaque native ID, and optionally a verified URL. Example types include `issue`, `ticket`, or another versioned provider-neutral work-item class.
+
+The origin is not necessarily the source target. A review may target one change while originating from a separate issue/ticket.
 
 ## Retained evidence
 
@@ -131,22 +160,22 @@ Version 3 generalizes v2's prompt/report wording to **Request** and **Result** w
 
 The digest is over the complete canonical UTF-8/LF evidence text. `hash` and `omit` never grant permission to publish plaintext elsewhere.
 
-## Publication decisions are independent records of authority and outcome
+## Publication decisions are independent from retention and artifacts
 
-Publication metadata must exist even when no external artifact was created. A private review therefore remains auditable without inventing an artifact.
+Publication metadata exists even when no external artifact is created. A private review remains auditable without inventing a review object.
 
-Each publication decision is a structured front-matter entry with at least:
+Each publication decision contains at least:
 
-- stable Crossdock publication ID/correlation marker;
+- stable Crossdock publication/correlation ID;
 - destination adapter and host;
-- target identity;
-- payload class: `request`, `result`, `summary`, `finding`, or another versioned class;
-- representation: `full`, `hash`, `omit`, or another explicitly supported publication representation;
+- opaque target identity;
+- payload class such as `request`, `result`, `summary`, or `finding`;
+- representation such as `full`, `hash`, or `omit`;
 - expected visibility/classification when knowable;
 - authority source;
 - requested state: `forbidden`, `not-requested`, or `authorized`;
-- outcome: `not-attempted`, `published`, `failed`, or `ambiguous`;
-- durable artifact reference when publication produced one and identity was reconciled.
+- **terminal completed-record outcome**: `not-attempted`, `published`, or `failed`;
+- durable artifact reference only when publication succeeded and identity was reconciled.
 
 Conceptual YAML:
 
@@ -165,13 +194,13 @@ publications:
     artifact_id: "artifact-review-1"
 ```
 
-A scalar such as `published_evidence: full` is insufficient because it cannot say *which* evidence class was published. An adapter must never infer permission to publish Request text merely because Result publication was authorized.
+A scalar `published_evidence: full` is insufficient because it cannot identify which evidence class was published. Authorizing Result publication never authorizes Request publication by implication.
 
-For `forbidden` or `not-requested`, `artifact_id` is null and no mutation is allowed. `authorized + not-attempted` may permit a later attempt according to workflow state. `ambiguous` prohibits blind retry until remote equivalence is reconciled.
+For `forbidden` or `not-requested`, no mutation is allowed and `artifact_id` is null. For a completed record, `authorized + not-attempted` represents an explicitly authorized action that was intentionally not part of this completed handoff; `failed` is a terminal known failure. A remotely ambiguous mutation does not finalize a task record at all until reconciled.
 
 ## Durable artifacts
 
-Durable artifacts are typed references stored structurally in front matter, not Markdown sections. Core fields are provider-neutral; adapters map provider-specific IDs into them.
+Durable artifacts are typed references stored structurally in front matter. Core fields are provider-neutral; adapters map provider-specific identifiers into them.
 
 Conceptual YAML:
 
@@ -188,61 +217,64 @@ artifacts:
     verification: "verified"
 ```
 
-The task record **must not contain a durable artifact entry for itself** when that entry depends on the record's own storage commit/hash/URL. That would be self-referential: writing the final identity into the bytes would change the identity being described.
+The task record **must not contain a durable artifact entry for itself** when that entry depends on the record's own storage commit/hash/URL. The final storage identity does not exist until the record bytes are committed.
 
-Task-record storage identity and post-write verification belong to the storage/handoff result or a separately persisted verification envelope/index. The immutable task record describes the delegated execution and external artifacts whose identity exists independently before record bytes are finalized.
+Task-record storage identity and post-write verification belong to the storage/handoff result or a separately persisted verification/index envelope. The immutable task record describes the delegated execution and independently existing external artifacts.
 
-## Review example
+## Independently traversable lineage
 
-A review task should include approximately:
+A bare `parent_task_id` is not sufficient for durable lineage because task-record location depends on storage destination/path/version and the parent may have been written to a different store.
 
-```yaml
-intent: "review"
-handoff_phase: "review-publication"
-source_adapter: "github"
-source_host: "github.com"
-target_repository: "owner/repo"
-target_pull_request: 42
-base_ref: "main"
-working_ref: "feature/example"
-target_commit: "abc123..."
-result_commit: null
-parent_task_id: "implementation-task-id"
-causal_artifact: null
-```
+When `parent_task_id` is present, v3 requires `parent_record`, describing the already-finalized parent's immutable location with:
 
-Request contains the review instructions under its selected retention mode. Result contains the review report under its selected retention mode. Publication decisions independently say whether any Result, summary, or finding may be sent to the source-control review surface.
+- storage adapter/type;
+- opaque locator/address understood by that storage adapter;
+- immutable version when the backend has one; and
+- SHA-256 of the exact parent-record bytes.
 
-A clean agent review never becomes human approval or merge authority.
+The child can therefore locate and verify its parent without relying on transient coordinator state. This is not self-reference: the **child** records identity for an already-finalized parent.
 
-## Findings and remediation lineage
+`causal_artifact` is optional and resolves **inside the parent record identified by `parent_record`**. It may name a durable typed review finding/thread artifact defined by that parent record. If no durable finding identity exists, lineage stops truthfully at the parent task.
 
-Crossdock must not invent a free-form `parent_finding_id` that cannot be resolved later.
-
-A remediation may point to:
-
-1. the parent review task alone; or
-2. a **typed durable finding artifact** referenced by `causal_artifact` when the parent execution/provider/source-control surface produced a stable, remotely or durably resolvable finding/thread identity.
-
-If Result evidence is `hash`/`omit` and no durable finding artifact exists, the remediation may truthfully say it descends from the review task, but it must not claim a more specific finding identity.
-
-Example:
+Example remediation:
 
 ```yaml
 intent: "remediate"
 parent_task_id: "review-task-id"
+parent_record:
+  storage_adapter: "github-task-record-storage"
+  locator: "..."
+  version: "..."
+  sha256: "..."
 causal_artifact: "artifact-review-thread-2"
-target_commit: "abc123..."
-result_commit: "def456..."
+source:
+  target_version: "abc123..."
+  result_version: "def456..."
 ```
 
-A later re-review is a new `review` task whose parent is the remediation and whose `target_commit` is `def456...`.
+A later re-review is a new `review` record whose parent is the remediation and whose `target_version` is the remediation's resulting source version.
+
+## Review example
+
+A review record identifies:
+
+- source adapter/host;
+- opaque repository and change identity;
+- base/working refs where meaningful;
+- exact `target_version` reviewed;
+- optional originating issue/work item;
+- exact retained Request and Result evidence policy;
+- independent publication decisions;
+- durable review/comment/thread artifacts only when actually produced and verified; and
+- independently resolvable parent lineage when the review follows implementation/remediation.
+
+A clean agent review never becomes human approval or merge authority.
 
 ## Investigation and verification
 
-An `investigate` task may have no publication decisions beyond explicitly recorded `not-requested`/`forbidden` policy and may produce no external durable artifacts.
+An `investigate` task may have no external publication and may produce no external durable artifacts. Its publication policy can explicitly say `forbidden` or `not-requested`.
 
-A `verify` task identifies the exact target state being checked. Its result is verification evidence, not an implementation result. If a fix is produced, model the fix as a separate remediation/implementation execution rather than silently mixing intents.
+A `verify` task identifies the exact target version being checked. Its result is verification evidence, not an implementation result. If a fix is produced, model it as a separate remediation/implementation execution rather than silently mixing intents.
 
 ## Scheduled occurrences
 
@@ -253,7 +285,7 @@ schedule_id: "nightly-review"
 schedule_occurrence: "2026-09-01T02:00:00Z"
 ```
 
-The intent remains `review`, `verify`, `investigate`, or another supported intent. Retrying the same occurrence must preserve idempotency and correlation rather than create an indistinguishable second occurrence.
+The intent remains `review`, `verify`, `investigate`, or another supported intent. Retrying the same occurrence must preserve correlation/idempotency rather than create an indistinguishable second occurrence.
 
 ## Parallel families
 
@@ -263,54 +295,70 @@ A family groups related work without collapsing executions:
 family_id: "crossdock-family-..."
 ```
 
-Each child has its own task ID, intent, target, agent execution, result, publication decisions, artifacts, and record.
+Each child has its own task ID, intent, source target, agent execution, result, publication decisions, artifacts, lineage, and immutable record.
 
-## Recovery and idempotency
+## Recoverable operational state and ambiguous mutations
 
-`recovery_state` describes whether all required remote mutations were reconciled for this completed record.
+A completed immutable record cannot truthfully contain an `ambiguous` publication outcome that later mutates into `published` or `failed`. Therefore ambiguity is prohibited in completed v3 records.
 
-Each external publication/mutation should carry a stable Crossdock correlation marker when the destination allows one. If a mutation may have succeeded but Crossdock cannot prove whether the intended remote artifact exists, its publication outcome becomes `ambiguous` and the workflow must stop rather than repeat the mutation.
+Crossdock needs a separate recoverable operational-state envelope, proposed as a distinct versioned concept such as `crossdock.recovery-state/v1`. It is **not** a completed provenance record. Its purpose is crash/retry safety while an execution is unresolved.
 
-Only after reconciliation may an ambiguous outcome become `published` or `failed`. A completed record must never claim `verified` for an artifact whose identity remains ambiguous.
+At minimum it preserves:
 
-Operational state for an unfinished/ambiguous execution may need a separate recoverable state document; it must not fabricate a completed immutable task record.
+- task ID and intended final record schema;
+- current workflow phase;
+- source target/version;
+- agent execution identity;
+- effective retention/publication policy;
+- publication correlation marker(s);
+- pre-mutation remote snapshot when available;
+- whether a remote mutation was invoked;
+- any candidate remote artifact identities discovered;
+- last verification/error state; and
+- enough information to prove equivalence or refuse retry.
+
+If a remote mutation may have succeeded but equivalence cannot be proven, recovery state becomes `ambiguous` and blind retry is prohibited. After reconciliation, Crossdock may complete the original execution with terminal `published` or `failed` publication metadata and then persist the immutable v3 task record. Recovery state may then be archived/deleted according to the configured lifecycle policy.
+
+If an operator chooses to abandon an unresolved execution, that abandonment should be recorded as a separate immutable operational event/record rather than rewriting a completed task record that never existed.
 
 ## Validation invariants
 
 A v3 writer/parser must enforce at least:
 
 1. `schema` is exactly `crossdock.task-record/v3`.
-2. `task_id`, intent, timestamps, agent adapter/provider/surface, and intent-required target fields are valid and non-empty.
-3. Source repository identity includes source adapter and host; `owner/repo` alone is insufficient.
-4. `base_ref` and `working_ref` remain independent fields and are required when the handoff semantics require them.
-5. `intent` is a supported v3 intent; scheduling/family values are never accepted as intents.
-6. `review` requires an exact `target_commit`; PR review requires a target PR/change identity.
-7. `review` never encodes human approval or merge authority.
-8. `remediate` identifies target state and resulting commit when code changed.
-9. Evidence modes, hashes, byte lengths, and presence/absence of payloads obey deterministic canonicalization rules.
-10. Evidence parsing is byte-length-delimited; arbitrary evidence text can never be parsed as metadata.
-11. `publication_count` and `artifact_count` match their structured front-matter collections.
-12. Every publication states payload class, representation, authority, requested state, and outcome independently of artifact creation.
-13. `hash`/`omit` retained evidence never grants plaintext publication authority.
-14. Durable artifact types are provider-neutral at the core boundary; provider-specific IDs remain adapter metadata.
-15. The task record never embeds a self-referential final storage identity that cannot exist before its bytes are committed.
-16. A specific causal finding is accepted only when it resolves to a durable typed artifact; otherwise lineage stops at the parent task.
-17. A completed record never claims a remote artifact was verified while publication identity is ambiguous.
-18. Scheduling and family membership never collapse multiple executions into one task record.
-19. Existing v1/v2 paths/content are never mutated as part of v3 migration.
-20. Destination-specific secret/classification preflight occurs before every external mutation.
+2. `task_id`, intent, timestamps, agent adapter/provider/surface, and intent-required source fields are valid and non-empty.
+3. Source identity includes adapter and host plus **opaque** native repository/change identifiers; core validation never assumes `owner/repo` or numeric PR syntax.
+4. Optional originating issue/work-item provenance uses a provider-neutral origin object with opaque native ID.
+5. `base_ref` and `working_ref` remain independent and are required where handoff semantics require them.
+6. `intent` is a supported v3 intent; scheduling/family values are never intents.
+7. `review` requires an exact target version and a source change identity.
+8. `review` never encodes human approval or merge authority.
+9. A source-changing branch-update/remediation records both target and resulting version.
+10. Evidence modes, hashes, byte lengths, and payload presence obey deterministic canonicalization rules.
+11. Evidence parsing is byte-length-delimited; arbitrary evidence text can never be parsed as metadata.
+12. Every publication states payload class, representation, authority, requested state, and **terminal** outcome independently of artifact creation.
+13. Ambiguous mutation state is rejected from completed v3 records and handled only in recoverable operational state.
+14. `hash`/`omit` retained evidence never grants plaintext publication authority.
+15. Durable artifact types are provider-neutral at the core boundary; provider-specific IDs remain adapter metadata.
+16. The task record never embeds its own self-referential final storage identity.
+17. `parent_task_id` requires an immutable parent-record locator/version/digest so lineage is independently traversable.
+18. A specific causal finding resolves within the identified parent record to a durable typed artifact; otherwise lineage stops at the parent task.
+19. A completed record never claims a remote artifact was verified unless reconciliation succeeded.
+20. Scheduling and family membership never collapse multiple executions into one task record.
+21. Existing v1/v2 paths/content are never mutated as part of v3 migration.
+22. Destination-specific secret/classification preflight occurs before every external mutation.
 
 ## Path compatibility
 
-For repository-scoped work, the proposed path remains:
+The current GitHub task-record store uses:
 
 ```text
 crossdock/tasks/<target-owner>/<target-repo>/<yyyy>/<mm>/<task-id>.md
 ```
 
-The record itself carries `source_adapter` and `source_host`, so identical repository slugs on different forges remain distinguishable even if a configured store uses the same path convention. A future multi-forge storage layout may add host/adapter path namespaces; that is a storage-addressing concern and must not rewrite existing records.
+That storage layout is an adapter convention, not a v3 core identity grammar. Because v3 `source.repository_id` is opaque, future stores/forges may require a host/adapter namespace or another addressing strategy. Storage adapters must expose an immutable locator that can later be embedded in child `parent_record` lineage.
 
-For work with no source repository, a future target namespace must be designed explicitly rather than inserting fake repository names. The first v3 implementation remains repository-scoped.
+Existing v1/v2 paths are never renamed. The first v3 implementation may remain GitHub/repository-scoped while the core model stays provider-neutral.
 
 ## Migration
 
@@ -318,20 +366,21 @@ There is no in-place migration.
 
 - v1 readers keep v1 semantics.
 - v2 readers keep v2 semantics.
-- v3-aware readers may read all three versions through version-specific parsers.
-- the writer switches to v3 only after parser/renderer, storage, handoff, and compatibility tests are complete.
+- v3-aware readers may read all three through version-specific parsers.
+- the writer switches to v3 only after parser/renderer, storage, lineage, handoff, recovery-state, and compatibility tests are complete.
 - historical task records remain byte-for-byte unchanged.
 
 ## Implementation sequence
 
-1. Freeze the exact deterministic YAML subset and byte-length evidence framing with golden fixtures.
-2. Implement v3 parser/renderer validation without changing the active v2 writer.
-3. Add source-target, publication-decision, typed-artifact, and lineage domain helpers.
-4. Add review-specific target/result validation and publication preflight.
-5. Extend storage/handoff code while preserving v1/v2 readers and immutable historical content.
-6. Implement one review path end-to-end behind an experimental capability flag.
-7. Add remediation and re-review lineage using durable typed finding artifacts where available.
-8. Perform live review → remediation → re-review validation against disposable public PRs.
-9. Promote adapter capability status only after dated compatibility evidence exists.
+1. Freeze deterministic metadata and byte-length evidence framing with golden fixtures.
+2. Implement an isolated v3 parser/renderer without changing the active v2 writer.
+3. Add opaque source/origin identity, publication-decision, durable-artifact, and immutable parent-locator helpers.
+4. Define and implement recoverable operational state for ambiguous remote mutations.
+5. Add review-specific target/result validation and publication preflight.
+6. Extend storage/handoff code while preserving v1/v2 readers and historical records.
+7. Implement one review path end-to-end behind an experimental capability flag.
+8. Add remediation/re-review lineage using parent-record locators and durable typed finding artifacts where available.
+9. Perform live review → remediation → re-review validation against disposable public PRs.
+10. Promote adapter capability status only after dated compatibility evidence exists.
 
 Related: #29, #30, #37, #38.


### PR DESCRIPTION
## Summary

- proposes `crossdock.task-record/v3` while preserving v1/v2 records byte-for-byte
- keeps intent, source-control handoff phase, scheduling, family membership, lineage, retained evidence, publication, and durable artifacts orthogonal
- defines review target SHA vs resulting implementation commit semantics
- keeps request/result evidence `full|hash|omit` but explicitly separates retention from external publication authority
- proposes provider-neutral typed durable artifacts with verification and publication metadata
- defines ambiguous remote recovery/idempotency rules
- includes review, remediation, investigation, verification, scheduled-occurrence, and parallel-family examples
- proposes validation invariants and an implementation sequence ending in live review → remediation → re-review evidence

## Why

The current v2 schema is intentionally implementation-oriented (`task_type: initial|update`). First-class persisted code review and other agent work need a successor model without weakening historical provenance semantics or silently overloading those values.

## Status

Design proposal only. Crossdock does not emit v3 records yet.

Related: #29, #30, #37, #38.