### PR TITLE
chore: add Crossdock code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default ownership for all files in Crossdock.
+# The main-branch ruleset requires Code Owner review for contributors,
+# while seedbed-ai-owner may use the configured ruleset bypass when the
+# one-person maintainer workflow would otherwise deadlock.
+* @seedbed-ai-owner


### PR DESCRIPTION
## Summary

- adds `.github/CODEOWNERS`
- assigns all repository paths to `@seedbed-ai-owner`
- complements the dedicated Code Owners ruleset while preserving the configured maintainer bypass for the current one-person team

## Validation

- repository CI (`test`) should pass before merge
