### PR TITLE
docs: strengthen public contributor and tester onramp

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions, ideas, and compatibility discussion
+    url: https://github.com/seedbed-ai/crossdock/discussions
+    about: Ask for help, discuss workflows, share ideas, or compare testing environments before opening a concrete issue.
+  - name: Security reporting guidance
+    url: https://github.com/seedbed-ai/crossdock/security
+    about: Review the repository security guidance before publicly reporting a vulnerability.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,57 @@
 # Crossdock
 
-Crossdock is an open-source workflow tool for moving bounded engineering work across conversation, coding-agent execution, and GitHub review without making the developer manually copy state between tools.
+Crossdock is an open-source workflow tool for moving bounded engineering work across conversation, AI coding-agent execution, and GitHub review without making the developer manually shuttle prompts, state, results, and recovery context between tools.
 
 > **Status:** early public development. The deterministic handoff core, loopback service, and experimental desktop Chromium browser adapter are public and under test. Crossdock does not yet have a supported end-user desktop/mobile release, and authenticated provider compatibility still requires live validation.
 
 > **Testers wanted:** independent public live testing is the current highest-value contribution. See [issue #28](https://github.com/seedbed-ai/crossdock/issues/28) and [`docs/testing/public-live-test.md`](docs/testing/public-live-test.md). No private Seedbed infrastructure is required.
 
-## What Crossdock is building
+## Why Crossdock?
+
+AI coding agents can already implement, review, investigate, and update software. The awkward part is often the handoff around them: carrying the right context into the task, keeping repository/PR identity straight, recovering safely after partial remote mutations, deciding what task evidence should be retained or published, and proving that the intended GitHub state actually exists.
+
+Crossdock is building that coordination layer. Its goal is not to replace ChatGPT, Codex, GitHub, or future providers; it is to make work move between them as one recoverable, user-controlled workflow.
 
 The initial route is ChatGPT → Codex Cloud → GitHub. Crossdock keeps that provider integration replaceable where practical rather than making provider names the product model.
 
-A completed Crossdock task creates an immutable task record with stable handoff metadata. Prompt and execution-report evidence are independently configurable: current records can retain full canonical evidence, retain only an integrity hash, or omit either evidence class entirely. Crossdock links the record from the initial pull request or a later top-level PR update comment and independently verifies the durable handoff before reporting completion.
+## What exists today
 
-Automation is a choice, not an assumption. The current dashboard supports both automatic handoff and review-before-handoff, plus explicit task-record storage. User-facing configuration is intended to expand rather than force one privacy, retention, storage, or workflow preference on every user.
+The public repository currently contains:
+
+- a deterministic task-record and GitHub handoff core;
+- a task-record storage adapter boundary with a GitHub-backed adapter;
+- independently configurable prompt/report evidence retention (`full`, `hash`, or `omit`);
+- idempotent immutable-record and update-comment retry handling;
+- a shared configuration resolver with explicit scope precedence;
+- a configurable loopback HTTP handoff service restricted to numeric loopback;
+- an experimental Manifest V3 browser adapter and responsive dashboard;
+- provider-neutral agent capability modeling and a proposed/experimental v3 task-record path for review and other non-implementation work;
+- public live-test, compatibility, architecture, configuration, security, development, and contribution documentation; and
+- GitHub Actions validation for the Node/JavaScript surfaces.
+
+The current v2 implementation still presents task-record linkage through the initial PR body and later update comments. Product direction now treats durable storage and GitHub-visible presentation as independent user choices; [issue #44](https://github.com/seedbed-ai/crossdock/issues/44) tracks configurable publication surfaces. The browser adapter remains fail-closed and experimental until authenticated live compatibility testing establishes current provider behavior.
+
+## Ways to help right now
+
+You do not need private Seedbed access to contribute. Particularly useful work includes:
+
+- **Live testing:** exercise the real ChatGPT → Codex → GitHub flow and report successes or failures in [#28](https://github.com/seedbed-ai/crossdock/issues/28).
+- **Browser compatibility:** help harden provider/UI boundaries and recovery behavior in [#11](https://github.com/seedbed-ai/crossdock/issues/11).
+- **Code review workflows:** help make agent review a first-class Crossdock task in [#29](https://github.com/seedbed-ai/crossdock/issues/29).
+- **Design:** contribute visual identity [#2](https://github.com/seedbed-ai/crossdock/issues/2), desktop UX [#3](https://github.com/seedbed-ai/crossdock/issues/3), or mobile UX [#4](https://github.com/seedbed-ai/crossdock/issues/4).
+- **Accessibility:** establish and exercise the cross-device baseline in [#14](https://github.com/seedbed-ai/crossdock/issues/14).
+- **Configuration/privacy/storage:** contribute to [#7](https://github.com/seedbed-ai/crossdock/issues/7), [#8](https://github.com/seedbed-ai/crossdock/issues/8), [#19](https://github.com/seedbed-ai/crossdock/issues/19), or [#44](https://github.com/seedbed-ai/crossdock/issues/44).
+- **Documentation/community:** improve the public documentation [#9](https://github.com/seedbed-ai/crossdock/issues/9) or contributor/community infrastructure [#10](https://github.com/seedbed-ai/crossdock/issues/10).
+
+Small, focused contributions are welcome. A reproducible compatibility failure, accessibility finding, documentation correction, or narrow regression test can be as useful as a larger feature.
+
+## Workflow and user control
+
+A completed Crossdock task creates an immutable task record with stable handoff metadata. Prompt and execution-report evidence are independently configurable: current records can retain full canonical evidence, retain only an integrity hash, or omit either evidence class entirely.
+
+Automation is a choice, not an assumption. The current dashboard supports both automatic handoff and review-before-handoff, plus explicit task-record storage. User-facing configuration is intended to expand rather than force one privacy, retention, storage, publication, or workflow preference on every user.
+
+Crossdock independently verifies durable handoff state before reporting completion and fails closed when repository, PR, branch, provider control, or recovery identity is ambiguous.
 
 ## Desktop and mobile
 
@@ -23,33 +62,24 @@ Crossdock targets one task-centric workflow across form factors:
 
 Both experiences must expose the same essential state and capabilities while using layouts and integration mechanisms appropriate to the device.
 
-## Current repository contents
+## Try it or contribute
 
-The repository currently contains:
+For local development, Crossdock currently requires Node.js 22 or newer and has no third-party runtime dependencies:
 
-- the deterministic task-record and GitHub handoff core;
-- a task-record storage adapter boundary with a GitHub-backed adapter;
-- configurable prompt/report evidence retention;
-- idempotent immutable-record and update-comment retry handling;
-- a shared configuration resolver with explicit scope precedence;
-- a loopback HTTP handoff service;
-- an experimental Manifest V3 browser adapter and responsive dashboard;
-- public live-test, architecture, configuration, security, development, and contribution documentation; and
-- GitHub Actions validation for the Node/JavaScript surfaces.
+```text
+npm test
+npm run check
+```
 
-The browser adapter remains fail-closed and experimental until authenticated live compatibility testing establishes the current provider DOM/control behavior.
+For the experimental authenticated workflow, follow [`docs/testing/public-live-test.md`](docs/testing/public-live-test.md) rather than guessing setup or manually rescuing a failed handoff. Successful environment reports are useful too; compatibility evidence is accumulated in [`docs/testing/compatibility.md`](docs/testing/compatibility.md).
 
-## Documentation
-
-Start with [`docs/README.md`](docs/README.md). Public testers should use [`docs/testing/public-live-test.md`](docs/testing/public-live-test.md). The documentation covers the workflow model, configurable task evidence, configuration, storage adapters, architecture/security boundaries, live-testing expectations, repository layout, and roadmap.
-
-## Contributing
-
-Crossdock is intended for public contribution. See [`CONTRIBUTING.md`](CONTRIBUTING.md) and the public issue tracker. UX, graphic design, documentation, accessibility, adapters, packaging, privacy controls, configuration, testing, code review, and implementation work are all expected contribution areas.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for contribution expectations and [`docs/README.md`](docs/README.md) for the full documentation map. GitHub Discussions is a good place for questions, ideas, workflow/design conversation, and testing/compatibility discussion that is not yet a concrete bug or scoped issue.
 
 ## Security and privacy
 
 Prompts and execution reports may contain private development context. Crossdock source is public; user task records are not therefore public. Users can choose how much prompt/report evidence to retain, and broader transient-data controls are under active design. See [`SECURITY.md`](SECURITY.md), [`docs/architecture/security-boundaries.md`](docs/architecture/security-boundaries.md), and [`docs/reference/task-record-schema.md`](docs/reference/task-record-schema.md).
+
+Never post access tokens, cookies, credentials, private prompts/reports, private repository contents, or other sensitive material in a public issue, discussion, screenshot, fixture, commit, or pull request.
 
 ## License
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,29 @@
+# Crossdock support and participation
+
+Crossdock is in early public development. The best place to ask depends on whether you have a question, an idea, a reproducible defect, a compatibility result, or a security concern.
+
+## Questions and workflow discussion
+
+Use [GitHub Discussions](https://github.com/seedbed-ai/crossdock/discussions) for setup questions, workflow ideas, design conversation, provider/integration questions, and testing or compatibility discussion that is not yet a reproducible bug.
+
+Questions from prospective contributors and testers are welcome. You do not need access to any private Seedbed repository or infrastructure.
+
+## Bugs and live-test results
+
+Use the public issue templates for reproducible defects and live compatibility results. For the experimental authenticated workflow, start with [`docs/testing/public-live-test.md`](docs/testing/public-live-test.md) and [testing issue #28](https://github.com/seedbed-ai/crossdock/issues/28).
+
+A failed live test is useful evidence. Record the failing state before manually repairing it, and keep private prompts, reports, repository contents, tokens, cookies, and credentials out of public reports.
+
+## Feature and design ideas
+
+Search existing issues and Discussions first. Small ideas and open-ended exploration fit Discussions; a concrete, bounded contribution or accepted problem belongs in an issue.
+
+Current public contribution areas include browser/provider adapters, code review workflows, desktop/mobile UX, accessibility, configuration, privacy, storage, documentation, testing, packaging, and visual identity.
+
+## Security
+
+Do not disclose an unpatched vulnerability publicly if doing so could put users at risk. Follow [`SECURITY.md`](SECURITY.md) for the current reporting boundary.
+
+## Current support level
+
+Crossdock does not yet claim supported end-user desktop/mobile releases or broadly verified authenticated-provider compatibility. The current Chromium extension + loopback service is experimental. Public compatibility evidence is tracked in [`docs/testing/compatibility.md`](docs/testing/compatibility.md).


### PR DESCRIPTION
## Summary

- rewrites the README opening around the concrete handoff problem Crossdock solves
- moves specific live-testing/design/accessibility/adapter/privacy contribution paths near the top
- reconciles stale PR-body/comment provenance wording with Product's now-configurable publication-surface direction
- adds a GitHub-recognized `SUPPORT.md` that routes questions, live-test results, features/design, and security appropriately
- adds issue-template contact links to Discussions and security guidance
- keeps experimental provider/release status explicit and avoids overstating live compatibility

## Goal

Make the repository understandable and inviting within the first few minutes for a prospective contributor or tester, especially before the next authenticated live-testing pass.

Relates to #9, #10, #28, and #44.