### PR TITLE
feat: add configurable provenance publication policy

### DIFF
--- a/docs/configuration/model.md
+++ b/docs/configuration/model.md
@@ -6,15 +6,16 @@ Schema identifier: `crossdock.config/v1`.
 
 ## Current fields
 
-The initial shared model contains:
+The shared model contains:
 
 - `handoff_mode`: `review` or `automatic`;
 - `evidence_policy.prompt`: `full`, `hash`, or `omit`;
 - `evidence_policy.report`: `full`, `hash`, or `omit`;
-- `storage`: `null` or a configured storage destination. The first implemented storage kind is `github` with `repository` and `branch`; and
-- `service_url`: the local loopback handoff-service origin used by the browser adapter.
+- `storage`: `null` or a configured task-record storage destination. The first implemented storage kind is `github` with `repository` and `branch`;
+- `service_url`: the local loopback handoff-service origin used by the browser adapter; and
+- `publication`: where task-record provenance is presented outside the durable task-record store.
 
-The model is intentionally small: a setting should not appear as implemented merely because Product intends to support it later. Additional privacy, lifecycle, provider, storage, and UI settings can extend versioned configuration as their behavior becomes real.
+The model is intentionally conservative: a setting should not appear as implemented merely because Product intends to support it later. Additional privacy, lifecycle, provider, storage, and UI settings can extend versioned configuration as their behavior becomes real.
 
 ## Precedence
 
@@ -27,9 +28,9 @@ The model is intentionally small: a setting should not appear as implemented mer
 5. repository settings;
 6. per-task settings.
 
-A more specific layer overrides only the fields it supplies. Partial evidence policy is merged field-by-field, so a repository can change report retention without accidentally changing prompt retention.
+A more specific layer overrides only the fields it supplies. Partial evidence policy and publication policy are merged field-by-field, so a repository can change one presentation surface without accidentally changing evidence retention or another surface.
 
-A more specific layer can explicitly set `storage: null` to clear an inherited destination. A workflow that requires durable storage must then fail clearly until another valid destination is selected.
+A more specific layer can explicitly set `storage: null` to clear an inherited destination, and can set `publication.committed_file: null` to disable an inherited committed-file destination. A workflow that requires durable storage must fail clearly until another valid destination is selected.
 
 Provider limitations and security rules are constraints, not hidden high-priority preference layers: validation should reject an unsupported effective configuration rather than silently overriding the user's visible choice.
 
@@ -46,11 +47,55 @@ The current compatibility defaults are:
     "report": "full"
   },
   "storage": null,
-  "service_url": "http://127.0.0.1:3210"
+  "service_url": "http://127.0.0.1:3210",
+  "publication": {
+    "change_description": "link",
+    "change_comment": "link",
+    "committed_file": null
+  }
 }
 ```
 
+The publication defaults preserve Crossdock's current behavior while making it explicit rather than mandatory Product policy. Existing v1 configuration documents that predate `publication` normalize to these compatibility defaults.
+
 These are implementation defaults, not permanent product policy. User-facing clients should display consequential effective choices before durable persistence or external mutation. Future evidence may justify different defaults without removing supported alternatives.
+
+## Publication and durable storage are separate
+
+`storage` answers where the immutable task record is persisted. `publication` answers whether and how a reference or summary is presented on other durable surfaces. Disabling a publication surface must never silently disable task-record persistence or widen retained prompt/report evidence somewhere else.
+
+The current source-control presentation fields are provider-neutral concepts:
+
+- `change_description`: provenance presentation in the source change's durable description/body;
+- `change_comment`: provenance presentation in a durable source-change comment/update surface.
+
+Each supports:
+
+- `link` — publish a durable task-record link/reference;
+- `summary` — publish a bounded summary representation under the later publication adapter's safety rules; or
+- `none` — do not publish provenance on that surface.
+
+It is valid to set both source-change surfaces to `none` while retaining an immutable task record elsewhere. Completion must remain truthful about what was and was not published.
+
+### Committed-file publication
+
+`publication.committed_file` is either `null` or an explicit destination object. The initial implemented configuration accepts only the GitHub adapter:
+
+```json
+{
+  "presentation": "reference",
+  "adapter": "github",
+  "repository": "owner/provenance",
+  "branch": "main",
+  "path_template": "crossdock/provenance/{task_id}.md"
+}
+```
+
+`presentation` currently supports `link` and `reference`. Crossdock deliberately does not expose a retained-record/full-record committed-file mode yet because that requires a separate self-reference, classification, and immutable-identity design rather than silently copying task-record bytes into another GitHub path.
+
+The path template must be repository-relative, may not traverse with `..`, and must contain `{task_id}` so independent task publications cannot collide by default. Actual publication still requires classification/secret preflight, retry/idempotency handling, remote verification, and mapping into the provider-neutral v3 publication/artifact contract before it can be considered implemented end-to-end.
+
+Configuration support therefore does not by itself mean the handoff service currently executes every configured publication destination. Unsupported execution combinations must fail clearly rather than being silently coerced back to the compatibility defaults.
 
 ## Loopback service URL
 
@@ -72,7 +117,7 @@ The Node service remains bound to `127.0.0.1`; its `PORT` environment variable m
 
 ## Strict validation
 
-Unknown scopes, unknown fields, unsupported enum values, malformed repositories, invalid service endpoints, and unsupported storage kinds fail instead of being ignored. This prevents a misspelled privacy or transport setting from silently falling back to broader behavior.
+Unknown scopes, unknown fields, unsupported enum values, malformed repositories, invalid service endpoints, unsafe committed-file templates, and unsupported storage/publication adapters fail instead of being ignored. This prevents a misspelled privacy, publication, or transport setting from silently falling back to broader behavior.
 
 Configuration parsers must not treat an unsupported future option as its nearest current equivalent. Preserve the user's requested value when possible, migrate it explicitly when a defined migration exists, or fail with an actionable explanation.
 
@@ -92,10 +137,10 @@ For compatibility, `type` may be omitted and currently normalizes to `github`. T
 
 ## Privacy and user agency
 
-Configuration is the user's statement of desired behavior. Crossdock must not silently retain more evidence, perform more automation, or select a broader data destination than the resolved configuration says.
+Configuration is the user's statement of desired behavior. Crossdock must not silently retain more evidence, perform more automation, or select a broader publication/data destination than the resolved configuration says.
 
 Durable evidence settings are not a complete data-lifecycle policy. Collection, transient processing, crash recovery, local history, diagnostics, expiration, deletion, encryption, and sharing are separate future configuration areas and must remain distinguishable as they are implemented.
 
 ## Effective summary
 
-The core exposes `effectiveConfigSummary()` so user interfaces can show the consequential resolved choices without exposing unrelated internal configuration structure. The summary includes the effective service URL because changing the transport endpoint changes where task data is sent. Desktop and mobile clients should use an equivalent effective-summary concept before a consequential action.
+The core exposes `effectiveConfigSummary()` so user interfaces can show the consequential resolved choices without exposing unrelated internal configuration structure. The summary includes the effective service URL and publication policy because those choices change where task data or provenance may be sent. Desktop and mobile clients should use an equivalent effective-summary concept before a consequential action.

--- a/src/config.js
+++ b/src/config.js
@@ -6,8 +6,18 @@ export { DEFAULT_SERVICE_URL, normalizeServiceUrl } from "./service-endpoint.js"
 export const CONFIG_SCHEMA = "crossdock.config/v1";
 export const HANDOFF_MODES = Object.freeze(["review", "automatic"]);
 export const CONFIG_SCOPES = Object.freeze(["global", "provider", "workspace", "repository", "task"]);
+export const PUBLICATION_PRESENTATIONS = Object.freeze(["link", "summary", "none"]);
+export const COMMITTED_FILE_PRESENTATIONS = Object.freeze(["link", "reference"]);
 
-const CONFIG_FIELDS = new Set(["schema", "handoff_mode", "evidence_policy", "storage", "service_url"]);
+const CONFIG_FIELDS = new Set(["schema", "handoff_mode", "evidence_policy", "storage", "service_url", "publication"]);
+const PUBLICATION_FIELDS = new Set(["change_description", "change_comment", "committed_file"]);
+const COMMITTED_FILE_FIELDS = new Set(["presentation", "adapter", "repository", "branch", "path_template"]);
+
+const DEFAULT_PUBLICATION = {
+  change_description: "link",
+  change_comment: "link",
+  committed_file: null,
+};
 
 export const DEFAULT_CONFIG = deepFreeze({
   schema: CONFIG_SCHEMA,
@@ -15,6 +25,7 @@ export const DEFAULT_CONFIG = deepFreeze({
   evidence_policy: { prompt: "full", report: "full" },
   storage: null,
   service_url: DEFAULT_SERVICE_URL,
+  publication: DEFAULT_PUBLICATION,
 });
 
 export function resolveConfig(scopes = {}) {
@@ -40,6 +51,9 @@ export function validateConfig(config, { requireStorage = false } = {}) {
   const storage = normalizeStorage(config.storage, "config.storage");
   const rawServiceUrl = Object.hasOwn(config, "service_url") ? config.service_url : DEFAULT_SERVICE_URL;
   const serviceUrl = normalizeServiceUrl(rawServiceUrl, "config.service_url");
+  const publication = Object.hasOwn(config, "publication")
+    ? normalizePublication(config.publication, "config.publication", true)
+    : clone(DEFAULT_PUBLICATION);
   if (requireStorage && storage == null) throw new Error("task-record storage must be configured");
 
   return {
@@ -48,6 +62,7 @@ export function validateConfig(config, { requireStorage = false } = {}) {
     evidence_policy: evidence,
     storage,
     service_url: serviceUrl,
+    publication,
   };
 }
 
@@ -63,6 +78,7 @@ export function effectiveConfigSummary(config) {
       branch: validated.storage.branch,
     },
     service_url: validated.service_url,
+    publication: clone(validated.publication),
   };
 }
 
@@ -79,6 +95,7 @@ function normalizeLayer(layer, scope) {
   if (Object.hasOwn(layer, "evidence_policy")) normalized.evidence_policy = normalizeEvidence(layer.evidence_policy, `${scope}.evidence_policy`, false);
   if (Object.hasOwn(layer, "storage")) normalized.storage = normalizeStorage(layer.storage, `${scope}.storage`);
   if (Object.hasOwn(layer, "service_url")) normalized.service_url = normalizeServiceUrl(layer.service_url, `${scope}.service_url`);
+  if (Object.hasOwn(layer, "publication")) normalized.publication = normalizePublication(layer.publication, `${scope}.publication`, false);
   return normalized;
 }
 
@@ -108,12 +125,64 @@ function normalizeStorage(value, label) {
   return { type, repository: value.repository, branch: value.branch };
 }
 
+function normalizePublication(value, label, requireAll) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new TypeError(`${label} must be an object`);
+  assertKnownKeys(value, PUBLICATION_FIELDS, label);
+  const result = {};
+
+  for (const field of ["change_description", "change_comment"]) {
+    if (!Object.hasOwn(value, field)) {
+      if (requireAll) throw new Error(`${label}.${field} is required`);
+      continue;
+    }
+    if (!PUBLICATION_PRESENTATIONS.includes(value[field])) {
+      throw new Error(`${label}.${field} must be one of: ${PUBLICATION_PRESENTATIONS.join(", ")}`);
+    }
+    result[field] = value[field];
+  }
+
+  if (!Object.hasOwn(value, "committed_file")) {
+    if (requireAll) throw new Error(`${label}.committed_file is required`);
+  } else {
+    result.committed_file = normalizeCommittedFile(value.committed_file, `${label}.committed_file`);
+  }
+  return result;
+}
+
+function normalizeCommittedFile(value, label) {
+  if (value == null) return null;
+  if (typeof value !== "object" || Array.isArray(value)) throw new TypeError(`${label} must be an object or null`);
+  assertKnownKeys(value, COMMITTED_FILE_FIELDS, label);
+
+  if (!COMMITTED_FILE_PRESENTATIONS.includes(value.presentation)) {
+    throw new Error(`${label}.presentation must be one of: ${COMMITTED_FILE_PRESENTATIONS.join(", ")}`);
+  }
+  const adapter = value.adapter ?? "github";
+  if (adapter !== "github") throw new Error(`${label}.adapter is unsupported: ${adapter}`);
+  if (typeof value.repository !== "string" || !/^[^/\s]+\/[^/\s]+$/.test(value.repository)) throw new Error(`${label}.repository must be owner/repo`);
+  if (typeof value.branch !== "string" || !value.branch.trim()) throw new Error(`${label}.branch is required`);
+  if (typeof value.path_template !== "string" || !value.path_template.trim()) throw new Error(`${label}.path_template is required`);
+
+  const pathTemplate = value.path_template.trim();
+  if (pathTemplate.startsWith("/") || pathTemplate.split("/").includes("..")) throw new Error(`${label}.path_template must be a repository-relative path`);
+  if (!pathTemplate.includes("{task_id}")) throw new Error(`${label}.path_template must include {task_id} for collision-safe publication`);
+
+  return {
+    presentation: value.presentation,
+    adapter,
+    repository: value.repository,
+    branch: value.branch.trim(),
+    path_template: pathTemplate,
+  };
+}
+
 function mergeLayer(base, layer) {
   const next = clone(base);
   if (Object.hasOwn(layer, "handoff_mode")) next.handoff_mode = layer.handoff_mode;
   if (Object.hasOwn(layer, "evidence_policy")) next.evidence_policy = { ...next.evidence_policy, ...layer.evidence_policy };
   if (Object.hasOwn(layer, "storage")) next.storage = layer.storage == null ? null : clone(layer.storage);
   if (Object.hasOwn(layer, "service_url")) next.service_url = layer.service_url;
+  if (Object.hasOwn(layer, "publication")) next.publication = { ...next.publication, ...clone(layer.publication) };
   return next;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 export { AGENT_CAPABILITIES_SCHEMA, AGENT_FEATURES, CAPABILITY_STATUSES, WORK_ITEM_INTENTS, intentCapabilityStatus, requireIntentSupport, supportsAgentFeature, supportsIntent, validateAgentCapabilities } from "./agent-capabilities.js";
 export { CODEX_BROWSER_CAPABILITIES } from "./adapters/codex/browser-capabilities.js";
-export { CONFIG_SCHEMA, CONFIG_SCOPES, DEFAULT_CONFIG, HANDOFF_MODES, effectiveConfigSummary, resolveConfig, validateConfig } from "./config.js";
+export { COMMITTED_FILE_PRESENTATIONS, CONFIG_SCHEMA, CONFIG_SCOPES, DEFAULT_CONFIG, HANDOFF_MODES, PUBLICATION_PRESENTATIONS, effectiveConfigSummary, resolveConfig, validateConfig } from "./config.js";
 export { GitHubClient } from "./github-client.js";
 export { buildPrBody, buildUpdateComment, persistTaskRecord, publishExistingInitialHandoff, publishInitialHandoff, publishUpdateHandoff } from "./handoff.js";
 export { createHandoffServer } from "./http-server.js";

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,6 +1,16 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { CONFIG_SCHEMA, DEFAULT_CONFIG, DEFAULT_SERVICE_URL, effectiveConfigSummary, normalizeServiceUrl, resolveConfig, validateConfig } from "../src/config.js";
+import {
+  COMMITTED_FILE_PRESENTATIONS,
+  CONFIG_SCHEMA,
+  DEFAULT_CONFIG,
+  DEFAULT_SERVICE_URL,
+  PUBLICATION_PRESENTATIONS,
+  effectiveConfigSummary,
+  normalizeServiceUrl,
+  resolveConfig,
+  validateConfig,
+} from "../src/config.js";
 
 test("defaults are explicit and immutable", () => {
   assert.equal(DEFAULT_CONFIG.schema, CONFIG_SCHEMA);
@@ -8,40 +18,103 @@ test("defaults are explicit and immutable", () => {
   assert.deepEqual(DEFAULT_CONFIG.evidence_policy, { prompt: "full", report: "full" });
   assert.equal(DEFAULT_CONFIG.storage, null);
   assert.equal(DEFAULT_CONFIG.service_url, DEFAULT_SERVICE_URL);
+  assert.deepEqual(DEFAULT_CONFIG.publication, {
+    change_description: "link",
+    change_comment: "link",
+    committed_file: null,
+  });
   assert.equal(DEFAULT_SERVICE_URL, "http://127.0.0.1:3210");
   assert.ok(Object.isFrozen(DEFAULT_CONFIG));
   assert.ok(Object.isFrozen(DEFAULT_CONFIG.evidence_policy));
+  assert.ok(Object.isFrozen(DEFAULT_CONFIG.publication));
 });
 
 test("scope precedence is global then provider then workspace then repository then task", () => {
   const config = resolveConfig({
-    global: { handoff_mode: "automatic", evidence_policy: { prompt: "hash" }, service_url: "http://127.0.0.1:3200" },
-    provider: { evidence_policy: { report: "hash" } },
+    global: {
+      handoff_mode: "automatic",
+      evidence_policy: { prompt: "hash" },
+      service_url: "http://127.0.0.1:3200",
+      publication: { change_description: "summary" },
+    },
+    provider: { evidence_policy: { report: "hash" }, publication: { change_comment: "none" } },
     workspace: { handoff_mode: "review", service_url: "http://127.0.0.1:3201" },
-    repository: { evidence_policy: { prompt: "omit" }, storage: { repository: "example/records", branch: "main" } },
-    task: { evidence_policy: { report: "omit" }, handoff_mode: "automatic", service_url: "http://127.0.0.1:4321" },
+    repository: {
+      evidence_policy: { prompt: "omit" },
+      storage: { repository: "example/records", branch: "main" },
+      publication: {
+        committed_file: {
+          presentation: "link",
+          repository: "example/provenance",
+          branch: "main",
+          path_template: "crossdock/{task_id}.md",
+        },
+      },
+    },
+    task: {
+      evidence_policy: { report: "omit" },
+      handoff_mode: "automatic",
+      service_url: "http://127.0.0.1:4321",
+      publication: { change_description: "none" },
+    },
   });
   assert.equal(config.handoff_mode, "automatic");
   assert.deepEqual(config.evidence_policy, { prompt: "omit", report: "omit" });
   assert.deepEqual(config.storage, { type: "github", repository: "example/records", branch: "main" });
   assert.equal(config.service_url, "http://127.0.0.1:4321");
+  assert.deepEqual(config.publication, {
+    change_description: "none",
+    change_comment: "none",
+    committed_file: {
+      presentation: "link",
+      adapter: "github",
+      repository: "example/provenance",
+      branch: "main",
+      path_template: "crossdock/{task_id}.md",
+    },
+  });
 });
 
-test("higher scope can explicitly clear inherited storage", () => {
+test("higher scope can explicitly clear inherited storage and committed-file publication", () => {
   const config = resolveConfig({
-    global: { storage: { repository: "example/records", branch: "main" } },
-    task: { storage: null },
+    global: {
+      storage: { repository: "example/records", branch: "main" },
+      publication: {
+        committed_file: {
+          presentation: "reference",
+          repository: "example/provenance",
+          branch: "main",
+          path_template: "crossdock/{task_id}.md",
+        },
+      },
+    },
+    task: { storage: null, publication: { committed_file: null } },
   });
   assert.equal(config.storage, null);
+  assert.equal(config.publication.committed_file, null);
 });
 
-test("partial evidence layers merge without changing unrelated evidence", () => {
-  const config = resolveConfig({ repository: { evidence_policy: { report: "hash" } } });
+test("partial evidence and publication layers preserve unrelated choices", () => {
+  const config = resolveConfig({
+    repository: {
+      evidence_policy: { report: "hash" },
+      publication: { change_comment: "summary" },
+    },
+  });
   assert.deepEqual(config.evidence_policy, { prompt: "full", report: "hash" });
+  assert.deepEqual(config.publication, {
+    change_description: "link",
+    change_comment: "summary",
+    committed_file: null,
+  });
 });
 
 test("resolved config does not mutate caller layers", () => {
-  const layer = { evidence_policy: { prompt: "omit" }, storage: { repository: "example/records", branch: "main" } };
+  const layer = {
+    evidence_policy: { prompt: "omit" },
+    storage: { repository: "example/records", branch: "main" },
+    publication: { change_description: "none" },
+  };
   const snapshot = structuredClone(layer);
   resolveConfig({ task: layer });
   assert.deepEqual(layer, snapshot);
@@ -51,11 +124,16 @@ test("unknown scope and config fields fail instead of being ignored", () => {
   assert.throws(() => resolveConfig({ mystery: {} }), /unknown field: mystery/);
   assert.throws(() => resolveConfig({ global: { made_up: true } }), /unknown field: made_up/);
   assert.throws(() => resolveConfig({ global: { evidence_policy: { unknown: "omit" } } }), /unknown field: unknown/);
+  assert.throws(() => resolveConfig({ global: { publication: { mystery: "none" } } }), /unknown field: mystery/);
 });
 
-test("invalid handoff and evidence modes fail clearly", () => {
+test("invalid handoff, evidence, and publication modes fail clearly", () => {
   assert.throws(() => resolveConfig({ task: { handoff_mode: "sometimes" } }), /handoff_mode/);
   assert.throws(() => resolveConfig({ task: { evidence_policy: { prompt: "sometimes" } } }), /evidence_policy.prompt/);
+  assert.throws(() => resolveConfig({ task: { publication: { change_description: "sometimes" } } }), /change_description/);
+  assert.throws(() => resolveConfig({ task: { publication: { committed_file: { presentation: "full", repository: "example/provenance", branch: "main", path_template: "crossdock/{task_id}.md" } } } }), /presentation/);
+  assert.deepEqual(PUBLICATION_PRESENTATIONS, ["link", "summary", "none"]);
+  assert.deepEqual(COMMITTED_FILE_PRESENTATIONS, ["link", "reference"]);
 });
 
 test("GitHub storage normalizes type and validates destination", () => {
@@ -63,6 +141,45 @@ test("GitHub storage normalizes type and validates destination", () => {
   assert.deepEqual(config.storage, { type: "github", repository: "example/private-records", branch: "records/main" });
   assert.throws(() => resolveConfig({ task: { storage: { type: "future", repository: "example/records", branch: "main" } } }), /unsupported/);
   assert.throws(() => resolveConfig({ task: { storage: { repository: "not-a-repo", branch: "main" } } }), /owner\/repo/);
+});
+
+test("committed-file publication is explicit and collision-safe", () => {
+  const config = resolveConfig({
+    task: {
+      publication: {
+        committed_file: {
+          presentation: "reference",
+          adapter: "github",
+          repository: "example/provenance",
+          branch: "records",
+          path_template: "provenance/{task_id}.md",
+        },
+      },
+    },
+  });
+  assert.equal(config.publication.committed_file.presentation, "reference");
+  assert.equal(config.publication.committed_file.path_template, "provenance/{task_id}.md");
+
+  for (const committed_file of [
+    { presentation: "link", adapter: "future", repository: "example/provenance", branch: "main", path_template: "p/{task_id}.md" },
+    { presentation: "link", repository: "bad", branch: "main", path_template: "p/{task_id}.md" },
+    { presentation: "link", repository: "example/provenance", branch: "main", path_template: "/p/{task_id}.md" },
+    { presentation: "link", repository: "example/provenance", branch: "main", path_template: "../p/{task_id}.md" },
+    { presentation: "link", repository: "example/provenance", branch: "main", path_template: "provenance/task.md" },
+  ]) {
+    assert.throws(() => resolveConfig({ task: { publication: { committed_file } } }), /(unsupported|owner\/repo|repository-relative|include \{task_id\})/);
+  }
+});
+
+test("all GitHub-visible source-change presentation may be disabled independently of storage", () => {
+  const config = resolveConfig({
+    task: {
+      storage: { repository: "example/private-records", branch: "main" },
+      publication: { change_description: "none", change_comment: "none", committed_file: null },
+    },
+  });
+  assert.deepEqual(config.publication, { change_description: "none", change_comment: "none", committed_file: null });
+  assert.deepEqual(config.storage, { type: "github", repository: "example/private-records", branch: "main" });
 });
 
 test("service URL accepts only an explicit numeric loopback origin", () => {
@@ -80,14 +197,20 @@ test("service URL accepts only an explicit numeric loopback origin", () => {
   ]) assert.throws(() => normalizeServiceUrl(invalid), /HTTP 127\.0\.0\.1 loopback origin with an explicit port/);
 });
 
-test("existing v1 config defaults only an absent service URL", () => {
+test("existing v1 config defaults newly introduced service URL and publication settings", () => {
   const legacy = {
     schema: CONFIG_SCHEMA,
     handoff_mode: "review",
     evidence_policy: { prompt: "full", report: "full" },
     storage: null,
   };
-  assert.equal(validateConfig(legacy).service_url, DEFAULT_SERVICE_URL);
+  const validated = validateConfig(legacy);
+  assert.equal(validated.service_url, DEFAULT_SERVICE_URL);
+  assert.deepEqual(validated.publication, {
+    change_description: "link",
+    change_comment: "link",
+    committed_file: null,
+  });
   assert.throws(() => validateConfig({ ...legacy, service_url: null }), /config\.service_url is required/);
   assert.throws(() => validateConfig({ ...legacy, service_url: "" }), /config\.service_url is required/);
 });
@@ -104,6 +227,7 @@ test("effectiveConfigSummary exposes consequential choices without extra config 
       evidence_policy: { prompt: "hash", report: "omit" },
       storage: { repository: "example/private-records", branch: "main" },
       service_url: "http://127.0.0.1:4321",
+      publication: { change_description: "summary", change_comment: "none" },
     },
   });
   assert.deepEqual(effectiveConfigSummary(config), {
@@ -112,5 +236,10 @@ test("effectiveConfigSummary exposes consequential choices without extra config 
     report_evidence: "omit",
     storage: { type: "github", repository: "example/private-records", branch: "main" },
     service_url: "http://127.0.0.1:4321",
+    publication: {
+      change_description: "summary",
+      change_comment: "none",
+      committed_file: null,
+    },
   });
 });


### PR DESCRIPTION
## Summary

- extends `crossdock.config/v1` with an explicit `publication` policy separate from immutable task-record `storage`
- preserves current compatibility defaults: task-record links in the source-change description and update comment, no committed-file publication
- supports independent `link | summary | none` choices for source-change description and comment surfaces
- allows higher-precedence scopes to override publication fields independently and explicitly clear inherited committed-file publication
- adds an explicit GitHub committed-file destination contract with `link | reference` presentation and collision-safe `{task_id}` path templates
- deliberately does not expose full retained-record committed-file publication before self-reference/classification semantics are implemented
- keeps all GitHub-visible provenance presentation optional while durable storage remains independently configured
- adds strict validation, effective-summary visibility, compatibility migration defaults, public documentation, and focused tests

## Important boundary

This PR defines and validates configuration only. It does not claim that the current handoff service executes every new publication combination yet; unsupported execution combinations must fail clearly in the implementation slice rather than silently coercing user configuration.

## Validation

GitHub Actions should run `npm test` and `npm run check` on Node 22.

Relates to #8 and #44.