### PR TITLE
feat: add report recovery configuration

### DIFF
--- a/docs/configuration/model.md
+++ b/docs/configuration/model.md
@@ -13,8 +13,9 @@ The shared model contains:
 - `evidence_policy.report`: `full`, `hash`, or `omit`;
 - `storage`: `null` or a configured task-record storage destination. The first implemented storage kind is `github` with `repository` and `branch`;
 - `service_url`: the local loopback handoff-service origin used by the browser adapter;
-- `publication`: where task-record provenance is presented outside the durable task-record store; and
-- `recovery.prompt`: whether prompt plaintext may be persisted locally for crash/restart recovery.
+- `publication`: where task-record provenance is presented outside the durable task-record store;
+- `recovery.prompt`: whether prompt plaintext may be persisted locally for crash/restart recovery; and
+- `recovery.report`: whether captured provider-report plaintext may be persisted locally for crash/restart recovery.
 
 The model is intentionally conservative: a setting should not appear as implemented merely because Product intends to support it later. Additional privacy, lifecycle, provider, storage, and UI settings can extend versioned configuration as their behavior becomes real.
 
@@ -55,29 +56,34 @@ The current compatibility defaults are:
     "committed_file": null
   },
   "recovery": {
-    "prompt": "persist"
+    "prompt": "persist",
+    "report": "persist"
   }
 }
 ```
 
-The compatibility defaults preserve Crossdock's historical behavior while making publication and recovery persistence explicit rather than hidden implementation policy. Existing v1 configuration documents and active browser tasks that predate these fields migrate to the historical defaults.
+The compatibility defaults preserve Crossdock's historical behavior while making publication and recovery persistence explicit rather than hidden implementation policy. Existing v1 configuration documents and active browser tasks that predate these fields migrate to the historical defaults. A config written during the prompt-only recovery era therefore gains `recovery.report: persist` rather than silently changing prior report recovery behavior.
 
 These are implementation defaults, not permanent product policy. User-facing clients should display consequential effective choices before durable persistence or external mutation. Future evidence may justify different defaults without removing supported alternatives.
 
 ## Recovery persistence is separate from durable evidence
 
-`evidence_policy.prompt` answers what prompt evidence belongs in the immutable task record. `recovery.prompt` answers whether prompt plaintext may be written into transient browser-local state while an active task is recoverable.
+`evidence_policy.prompt` and `evidence_policy.report` answer what evidence belongs in the immutable task record. `recovery.prompt` and `recovery.report` independently answer whether the corresponding plaintext may be written into transient browser-local state while an active task is recoverable.
 
-The first implemented prompt recovery modes are:
+Both recovery fields use the same modes:
 
-- `persist` — allow active-task prompt plaintext to be stored in `chrome.storage.local` so a dashboard/browser restart can continue a task that still needs the original prompt bytes; and
-- `memory` — keep prompt plaintext only in the live dashboard JavaScript state after capture/submission and remove it from both persisted dashboard-form state and persisted active-task state.
+- `persist` — allow that active-task plaintext to be stored in local recovery state so a dashboard/browser restart can continue a task that still needs the original bytes; and
+- `memory` — keep that plaintext only in the live process after capture and remove it from persisted active-task recovery state.
 
-`memory` is intentionally a privacy/recoverability tradeoff, not an encryption feature. While the dashboard remains alive, Crossdock can complete normally using the in-memory prompt. After a restart, the prompt is intentionally unavailable. If durable prompt evidence is `full` or `hash`, Crossdock fails recovery clearly because it cannot truthfully reconstruct the missing original bytes. If durable prompt evidence is `omit`, recovery may continue without the prompt because the final task record does not require prompt plaintext or a prompt digest.
+Prompt recovery also covers the persisted dashboard form because prompt content exists there before task submission. Memory-only prompt recovery therefore removes prompt plaintext from both the persisted form and active-task state.
 
-Changing the visible recovery preference after a task starts does not alter that task's frozen recovery policy. Crossdock never silently turns `memory` into `persist` merely to make recovery succeed.
+`memory` is intentionally a privacy/recoverability tradeoff, not an encryption feature. While the dashboard remains alive, Crossdock can complete normally using in-memory content. After a restart, intentionally discarded bytes are unavailable. If durable evidence is `full` or `hash`, Crossdock must fail recovery clearly when those original bytes are already required; it must not reconstruct, recapture, or silently widen persistence. If the corresponding durable evidence is `omit`, recovery may continue without those bytes.
 
-This first slice covers prompt plaintext only. Report recovery persistence, encrypted/OS-secure recovery storage, retention windows, completed-task history, diagnostics, expiration, and deletion remain separate lifecycle work rather than being inferred from `recovery.prompt`.
+For reports, the bytes only become recovery-critical after the provider report has actually been captured. A task configured with `recovery.report: memory` can therefore restart normally while it is still waiting for provider completion. After report capture, a restart may make `full`/`hash` report evidence intentionally unrecoverable; report `omit` remains recoverable without report bytes.
+
+Changing a visible recovery preference after a task starts must not alter that task's frozen recovery policy. Crossdock never silently turns `memory` into `persist` merely to make recovery succeed.
+
+The shared configuration contract now carries both recovery choices. The current browser UI still exposes prompt recovery only; report-recovery UI/state wiring is the next execution slice. Encrypted/OS-secure recovery storage, retention windows, completed-task history, diagnostics, expiration, and deletion remain separate lifecycle work rather than being inferred from these fields.
 
 ## Publication and durable storage are separate
 

--- a/src/config.js
+++ b/src/config.js
@@ -8,12 +8,14 @@ export const HANDOFF_MODES = Object.freeze(["review", "automatic"]);
 export const CONFIG_SCOPES = Object.freeze(["global", "provider", "workspace", "repository", "task"]);
 export const PUBLICATION_PRESENTATIONS = Object.freeze(["link", "summary", "none"]);
 export const COMMITTED_FILE_PRESENTATIONS = Object.freeze(["link", "reference"]);
-export const RECOVERY_PROMPT_MODES = Object.freeze(["persist", "memory"]);
+export const RECOVERY_CONTENT_MODES = Object.freeze(["persist", "memory"]);
+export const RECOVERY_PROMPT_MODES = RECOVERY_CONTENT_MODES;
+export const RECOVERY_REPORT_MODES = RECOVERY_CONTENT_MODES;
 
 const CONFIG_FIELDS = new Set(["schema", "handoff_mode", "evidence_policy", "storage", "service_url", "publication", "recovery"]);
 const PUBLICATION_FIELDS = new Set(["change_description", "change_comment", "committed_file"]);
 const COMMITTED_FILE_FIELDS = new Set(["presentation", "adapter", "repository", "branch", "path_template"]);
-const RECOVERY_FIELDS = new Set(["prompt"]);
+const RECOVERY_FIELDS = new Set(["prompt", "report"]);
 
 const DEFAULT_PUBLICATION = {
   change_description: "link",
@@ -21,7 +23,7 @@ const DEFAULT_PUBLICATION = {
   committed_file: null,
 };
 
-const DEFAULT_RECOVERY = { prompt: "persist" };
+const DEFAULT_RECOVERY = { prompt: "persist", report: "persist" };
 
 export const DEFAULT_CONFIG = deepFreeze({
   schema: CONFIG_SCHEMA,
@@ -133,12 +135,15 @@ function normalizeRecovery(value, label, requireAll) {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new TypeError(`${label} must be an object`);
   assertKnownKeys(value, RECOVERY_FIELDS, label);
   const result = {};
-  if (!Object.hasOwn(value, "prompt")) {
-    if (requireAll) throw new Error(`${label}.prompt is required`);
-    return result;
+  for (const field of ["prompt", "report"]) {
+    if (!Object.hasOwn(value, field)) {
+      if (requireAll && field === "prompt") throw new Error(`${label}.${field} is required`);
+      if (requireAll && field === "report") result.report = DEFAULT_RECOVERY.report;
+      continue;
+    }
+    if (!RECOVERY_CONTENT_MODES.includes(value[field])) throw new Error(`${label}.${field} must be one of: ${RECOVERY_CONTENT_MODES.join(", ")}`);
+    result[field] = value[field];
   }
-  if (!RECOVERY_PROMPT_MODES.includes(value.prompt)) throw new Error(`${label}.prompt must be one of: ${RECOVERY_PROMPT_MODES.join(", ")}`);
-  result.prompt = value.prompt;
   return result;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 export { AGENT_CAPABILITIES_SCHEMA, AGENT_FEATURES, CAPABILITY_STATUSES, WORK_ITEM_INTENTS, intentCapabilityStatus, requireIntentSupport, supportsAgentFeature, supportsIntent, validateAgentCapabilities } from "./agent-capabilities.js";
 export { CODEX_BROWSER_CAPABILITIES } from "./adapters/codex/browser-capabilities.js";
-export { COMMITTED_FILE_PRESENTATIONS, CONFIG_SCHEMA, CONFIG_SCOPES, DEFAULT_CONFIG, HANDOFF_MODES, PUBLICATION_PRESENTATIONS, RECOVERY_PROMPT_MODES, effectiveConfigSummary, resolveConfig, validateConfig, validatePublicationPolicy } from "./config.js";
+export { COMMITTED_FILE_PRESENTATIONS, CONFIG_SCHEMA, CONFIG_SCOPES, DEFAULT_CONFIG, HANDOFF_MODES, PUBLICATION_PRESENTATIONS, RECOVERY_CONTENT_MODES, RECOVERY_PROMPT_MODES, RECOVERY_REPORT_MODES, effectiveConfigSummary, resolveConfig, validateConfig, validatePublicationPolicy } from "./config.js";
 export { GitHubClient } from "./github-client.js";
 export { buildPrBody, buildUpdateComment, persistTaskRecord, publishExistingInitialHandoff, publishInitialHandoff, publishUpdateHandoff } from "./handoff.js";
 export { createHandoffServer } from "./http-server.js";

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -7,6 +7,7 @@ import {
   DEFAULT_SERVICE_URL,
   PUBLICATION_PRESENTATIONS,
   RECOVERY_PROMPT_MODES,
+  RECOVERY_REPORT_MODES,
   effectiveConfigSummary,
   normalizeServiceUrl,
   resolveConfig,
@@ -24,7 +25,7 @@ test("defaults are explicit and immutable", () => {
     change_comment: "link",
     committed_file: null,
   });
-  assert.deepEqual(DEFAULT_CONFIG.recovery, { prompt: "persist" });
+  assert.deepEqual(DEFAULT_CONFIG.recovery, { prompt: "persist", report: "persist" });
   assert.equal(DEFAULT_SERVICE_URL, "http://127.0.0.1:3210");
   assert.ok(Object.isFrozen(DEFAULT_CONFIG));
   assert.ok(Object.isFrozen(DEFAULT_CONFIG.evidence_policy));
@@ -39,7 +40,7 @@ test("scope precedence is global then provider then workspace then repository th
       evidence_policy: { prompt: "hash" },
       service_url: "http://127.0.0.1:3200",
       publication: { change_description: "summary" },
-      recovery: { prompt: "persist" },
+      recovery: { prompt: "persist", report: "memory" },
     },
     provider: { evidence_policy: { report: "hash" }, publication: { change_comment: "none" } },
     workspace: { handoff_mode: "review", service_url: "http://127.0.0.1:3201" },
@@ -67,7 +68,7 @@ test("scope precedence is global then provider then workspace then repository th
   assert.deepEqual(config.evidence_policy, { prompt: "omit", report: "omit" });
   assert.deepEqual(config.storage, { type: "github", repository: "example/records", branch: "main" });
   assert.equal(config.service_url, "http://127.0.0.1:4321");
-  assert.deepEqual(config.recovery, { prompt: "memory" });
+  assert.deepEqual(config.recovery, { prompt: "memory", report: "memory" });
   assert.deepEqual(config.publication, {
     change_description: "none",
     change_comment: "none",
@@ -102,6 +103,7 @@ test("higher scope can explicitly clear inherited storage and committed-file pub
 
 test("partial evidence, publication, and recovery layers preserve unrelated choices", () => {
   const config = resolveConfig({
+    provider: { recovery: { report: "memory" } },
     repository: {
       evidence_policy: { report: "hash" },
       publication: { change_comment: "summary" },
@@ -114,7 +116,7 @@ test("partial evidence, publication, and recovery layers preserve unrelated choi
     change_comment: "summary",
     committed_file: null,
   });
-  assert.deepEqual(config.recovery, { prompt: "memory" });
+  assert.deepEqual(config.recovery, { prompt: "memory", report: "memory" });
 });
 
 test("resolved config does not mutate caller layers", () => {
@@ -122,7 +124,7 @@ test("resolved config does not mutate caller layers", () => {
     evidence_policy: { prompt: "omit" },
     storage: { repository: "example/records", branch: "main" },
     publication: { change_description: "none" },
-    recovery: { prompt: "memory" },
+    recovery: { prompt: "memory", report: "memory" },
   };
   const snapshot = structuredClone(layer);
   resolveConfig({ task: layer });
@@ -134,7 +136,7 @@ test("unknown scope and config fields fail instead of being ignored", () => {
   assert.throws(() => resolveConfig({ global: { made_up: true } }), /unknown field: made_up/);
   assert.throws(() => resolveConfig({ global: { evidence_policy: { unknown: "omit" } } }), /unknown field: unknown/);
   assert.throws(() => resolveConfig({ global: { publication: { mystery: "none" } } }), /unknown field: mystery/);
-  assert.throws(() => resolveConfig({ global: { recovery: { report: "memory" } } }), /unknown field: report/);
+  assert.throws(() => resolveConfig({ global: { recovery: { future: "memory" } } }), /unknown field: future/);
 });
 
 test("invalid handoff, evidence, publication, and recovery modes fail clearly", () => {
@@ -143,9 +145,11 @@ test("invalid handoff, evidence, publication, and recovery modes fail clearly", 
   assert.throws(() => resolveConfig({ task: { publication: { change_description: "sometimes" } } }), /change_description/);
   assert.throws(() => resolveConfig({ task: { publication: { committed_file: { presentation: "full", repository: "example/provenance", branch: "main", path_template: "crossdock/{task_id}.md" } } } }), /presentation/);
   assert.throws(() => resolveConfig({ task: { recovery: { prompt: "encrypted" } } }), /recovery.prompt/);
+  assert.throws(() => resolveConfig({ task: { recovery: { report: "encrypted" } } }), /recovery.report/);
   assert.deepEqual(PUBLICATION_PRESENTATIONS, ["link", "summary", "none"]);
   assert.deepEqual(COMMITTED_FILE_PRESENTATIONS, ["link", "reference"]);
   assert.deepEqual(RECOVERY_PROMPT_MODES, ["persist", "memory"]);
+  assert.deepEqual(RECOVERY_REPORT_MODES, ["persist", "memory"]);
 });
 
 test("GitHub storage normalizes type and validates destination", () => {
@@ -223,7 +227,16 @@ test("existing v1 config defaults newly introduced service URL, publication, and
     change_comment: "link",
     committed_file: null,
   });
-  assert.deepEqual(validated.recovery, { prompt: "persist" });
+  assert.deepEqual(validated.recovery, { prompt: "persist", report: "persist" });
+
+  const promptRecoveryEra = validateConfig({
+    ...legacy,
+    service_url: DEFAULT_SERVICE_URL,
+    publication: { change_description: "link", change_comment: "link", committed_file: null },
+    recovery: { prompt: "memory" },
+  });
+  assert.deepEqual(promptRecoveryEra.recovery, { prompt: "memory", report: "persist" });
+
   assert.throws(() => validateConfig({ ...legacy, service_url: null }), /config\.service_url is required/);
   assert.throws(() => validateConfig({ ...legacy, service_url: "" }), /config\.service_url is required/);
 });
@@ -241,7 +254,7 @@ test("effectiveConfigSummary exposes consequential choices without extra config 
       storage: { repository: "example/private-records", branch: "main" },
       service_url: "http://127.0.0.1:4321",
       publication: { change_description: "summary", change_comment: "none" },
-      recovery: { prompt: "memory" },
+      recovery: { prompt: "memory", report: "memory" },
     },
   });
   assert.deepEqual(effectiveConfigSummary(config), {
@@ -255,6 +268,6 @@ test("effectiveConfigSummary exposes consequential choices without extra config 
       change_comment: "none",
       committed_file: null,
     },
-    recovery: { prompt: "memory" },
+    recovery: { prompt: "memory", report: "memory" },
   });
 });


### PR DESCRIPTION
## Summary
- extend `crossdock.config/v1` recovery policy with independent `report: persist | memory`
- preserve historical behavior by defaulting missing report recovery to `persist`
- merge prompt/report recovery independently across config scopes
- expose report recovery in the effective configuration summary and public exports
- document the distinction between durable report evidence and transient report recovery persistence

## Compatibility
Existing v1 configs with no recovery section still default both prompt and report recovery to `persist`. Configs written after prompt recovery was introduced but before report recovery gain only the historical `report: persist` default; their explicit prompt choice is preserved.

## Scope
This is the shared configuration contract only. Browser UI/state wiring follows separately so the contract can be validated without conflating it with provider/browser execution behavior.

## Validation
- existing config coverage retained
- new precedence, validation, migration, and effective-summary assertions
- CI: `npm test` and `npm run check`

Relates to #19.