### PR TITLE
docs: define pre-1.0 release and compatibility policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,17 @@ The public repository currently contains:
 - a deterministic task-record and GitHub handoff core;
 - a task-record storage adapter boundary with a GitHub-backed adapter;
 - independently configurable prompt/report evidence retention (`full`, `hash`, or `omit`);
+- independently configurable PR-body/update-comment provenance presentation (`link` or `none`) while durable task-record storage remains required by the current handoff path;
+- configurable prompt crash-recovery persistence (`persist` or `memory`) plus provider-report recovery state semantics and shared report-recovery configuration;
 - idempotent immutable-record and update-comment retry handling;
 - a shared configuration resolver with explicit scope precedence;
 - a configurable loopback HTTP handoff service restricted to numeric loopback;
 - an experimental Manifest V3 browser adapter and responsive dashboard;
-- provider-neutral agent capability modeling and a proposed/experimental v3 task-record path for review and other non-implementation work;
-- public live-test, compatibility, architecture, configuration, security, development, and contribution documentation; and
+- provider-neutral agent capability modeling and an experimental v3 task-record codec for review and other non-implementation work;
+- public live-test, compatibility, architecture, configuration, security, release-policy, development, and contribution documentation; and
 - GitHub Actions validation for the Node/JavaScript surfaces.
 
-The current v2 implementation still presents task-record linkage through the initial PR body and later update comments. Product direction now treats durable storage and GitHub-visible presentation as independent user choices; [issue #44](https://github.com/seedbed-ai/crossdock/issues/44) tracks configurable publication surfaces. The browser adapter remains fail-closed and experimental until authenticated live compatibility testing establishes current provider behavior.
+The browser adapter currently executes `link` and `none` provenance choices for initial PR descriptions and later update comments. `summary` and committed-file publication remain intentionally unimplemented until their safety/idempotency semantics are complete. Report-recovery browser UI/state wiring is tracked in [#54](https://github.com/seedbed-ai/crossdock/issues/54). The adapter remains fail-closed and experimental until authenticated live compatibility testing establishes current provider behavior.
 
 ## Ways to help right now
 
@@ -49,7 +51,7 @@ Small, focused contributions are welcome. A reproducible compatibility failure, 
 
 A completed Crossdock task creates an immutable task record with stable handoff metadata. Prompt and execution-report evidence are independently configurable: current records can retain full canonical evidence, retain only an integrity hash, or omit either evidence class entirely.
 
-Automation is a choice, not an assumption. The current dashboard supports both automatic handoff and review-before-handoff, plus explicit task-record storage. User-facing configuration is intended to expand rather than force one privacy, retention, storage, publication, or workflow preference on every user.
+Automation is a choice, not an assumption. The current dashboard supports both automatic handoff and review-before-handoff, explicit task-record storage, configurable prompt recovery persistence, and independent `link`/`none` publication on the currently implemented PR surfaces. User-facing configuration is intended to expand rather than force one privacy, retention, storage, publication, or workflow preference on every user.
 
 Crossdock independently verifies durable handoff state before reporting completion and fails closed when repository, PR, branch, provider control, or recovery identity is ambiguous.
 
@@ -71,13 +73,13 @@ npm test
 npm run check
 ```
 
-For the experimental authenticated workflow, follow [`docs/testing/public-live-test.md`](docs/testing/public-live-test.md) rather than guessing setup or manually rescuing a failed handoff. Successful environment reports are useful too; compatibility evidence is accumulated in [`docs/testing/compatibility.md`](docs/testing/compatibility.md).
+For the experimental authenticated workflow, follow [`docs/testing/public-live-test.md`](docs/testing/public-live-test.md) rather than guessing setup or manually rescuing a failed handoff. Successful environment reports are useful too; compatibility evidence is accumulated in [`docs/testing/compatibility.md`](docs/testing/compatibility.md). See [`docs/releases.md`](docs/releases.md) for what experimental, verified, and supported mean before 1.0.
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for contribution expectations and [`docs/README.md`](docs/README.md) for the full documentation map. GitHub Discussions is a good place for questions, ideas, workflow/design conversation, and testing/compatibility discussion that is not yet a concrete bug or scoped issue.
 
 ## Security and privacy
 
-Prompts and execution reports may contain private development context. Crossdock source is public; user task records are not therefore public. Users can choose how much prompt/report evidence to retain, and broader transient-data controls are under active design. See [`SECURITY.md`](SECURITY.md), [`docs/architecture/security-boundaries.md`](docs/architecture/security-boundaries.md), and [`docs/reference/task-record-schema.md`](docs/reference/task-record-schema.md).
+Prompts and execution reports may contain private development context. Crossdock source is public; user task records are not therefore public. Users can choose how much prompt/report evidence to retain, and transient recovery controls are being implemented independently from durable evidence choices. See [`SECURITY.md`](SECURITY.md), [`docs/architecture/security-boundaries.md`](docs/architecture/security-boundaries.md), and [`docs/reference/task-record-schema.md`](docs/reference/task-record-schema.md).
 
 Never post access tokens, cookies, credentials, private prompts/reports, private repository contents, or other sensitive material in a public issue, discussion, screenshot, fixture, commit, or pull request.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Crossdock is in early public development. These documents describe the intended 
 - [`testing/README.md`](testing/README.md) — automated vs live validation and reporting guidance.
 - [`testing/public-live-test.md`](testing/public-live-test.md) — provider-neutral desktop live-test steps for public testers.
 - [`testing/compatibility.md`](testing/compatibility.md) — dated public evidence for tested browser/OS/workflow combinations.
+- [`releases.md`](releases.md) — pre-1.0 versioning, compatibility levels, migration/deprecation rules, and release-note expectations.
 
 ## Concepts
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,111 @@
+# Release and Compatibility Policy
+
+Crossdock is in early public development. This policy defines what version numbers, compatibility claims, and migration guarantees mean before 1.0 so contributors and testers can distinguish implemented code from verified or supported behavior.
+
+## Pre-1.0 versioning
+
+Crossdock uses semantic-version-shaped releases (`0.MINOR.PATCH`) before 1.0.
+
+- **Patch** releases should contain compatible fixes, documentation, tests, and narrowly compatible behavior changes.
+- **Minor** releases may add features and may contain breaking changes while the product and provider integrations are still stabilizing.
+- Every release that changes observable behavior, configuration, schemas, provider assumptions, or setup requirements must say so in its release notes.
+
+Before 1.0, a minor-version bump is the normal signal for an intentional breaking product/API/configuration change. Security fixes or provider breakages may require faster changes; those still need an explicit release-note entry rather than being hidden as compatibility.
+
+## Compatibility levels
+
+Crossdock uses three distinct compatibility concepts.
+
+### Experimental
+
+Implemented and available for testing, but not backed by enough current live evidence for a compatibility commitment. Experimental integrations may change as provider surfaces evolve.
+
+### Verified
+
+A particular workflow completed successfully on a stated Crossdock ref, date, operating system, browser/client, and provider surface. Verification is evidence, not a perpetual guarantee. The public compatibility matrix records this level.
+
+### Supported
+
+A release explicitly declares the integration or platform supported and states the supported boundary. Support is a maintainer commitment to treat regressions inside that boundary as release defects, subject to upstream provider availability and documented constraints.
+
+No integration becomes supported merely because code exists or one live test succeeds. Until a release explicitly says otherwise, the current browser/provider path remains experimental even after individual environments become verified.
+
+## Current platform boundary
+
+At the time this policy was introduced:
+
+- the Node handoff core and repository tests are development surfaces;
+- the desktop Chromium-compatible Manifest V3 extension + loopback service is experimental;
+- authenticated ChatGPT/Codex/GitHub browser compatibility requires dated live evidence;
+- mobile is not an implemented provider-integration path; and
+- future desktop wrappers, mobile clients, provider APIs/SDKs, and additional adapters must declare their own compatibility level rather than inheriting one implicitly.
+
+See [`testing/compatibility.md`](testing/compatibility.md) for live evidence rather than inferring support from this document.
+
+## Provider UI and adapter breakage
+
+Provider-specific behavior belongs behind adapters where practical. Provider UI changes can break an adapter without a Crossdock source change.
+
+When a provider surface changes materially:
+
+1. keep prior compatibility evidence as historical evidence;
+2. mark newly observed failures explicitly rather than deleting older successes;
+3. avoid claiming current verification until the affected path is re-tested; and
+4. fail closed when Crossdock cannot identify the intended control, repository, PR, branch, task, or result unambiguously.
+
+A provider workaround must not silently weaken privacy, evidence, publication, recovery, or remote-verification semantics.
+
+## Configuration compatibility
+
+The configuration schema has its own explicit schema identifier. Compatible additions to an existing schema version may define deterministic defaults for fields that older documents could not contain.
+
+Configuration handling must:
+
+- preserve an explicit user choice when a defined migration exists;
+- use documented historical defaults only for genuinely absent legacy fields;
+- reject explicit invalid/unsupported values rather than treating them as missing;
+- merge scoped partial configuration without resetting unrelated choices; and
+- fail with an actionable error instead of silently coercing a future or misspelled option.
+
+A change that cannot obey those rules should use a new configuration schema version rather than redefining old bytes ambiguously.
+
+## Task-record compatibility
+
+Immutable task records are historical evidence. Released task-record schema versions are never migrated in place or rewritten merely because Crossdock gains a newer schema.
+
+A new task-record schema version may add capabilities or change representation, but existing records retain their original schema identity and bytes. Readers may add support for older versions; writers must not relabel an old record as a new version without constructing a new record under the new contract.
+
+Production adoption of a newer schema is separate from implementing or experimenting with its codec.
+
+## Deprecation
+
+Before 1.0, Crossdock will prefer an explicit deprecation period when a safe compatibility path exists, but it does not promise a fixed number of releases for every experimental surface. Provider removals, security boundaries, or dangerous behavior may require immediate disablement.
+
+A deprecation should state:
+
+- what is being deprecated;
+- the replacement or migration path, when one exists;
+- the earliest release in which removal may occur; and
+- whether the change affects stored data, configuration, adapters, or user-visible workflow behavior.
+
+Silent deprecation is not acceptable.
+
+## Release notes
+
+Contributor-facing releases should summarize at least:
+
+- notable user-visible changes;
+- compatibility level changes;
+- provider/browser/platform observations that materially affect use;
+- configuration or schema additions/migrations;
+- privacy/security boundary changes;
+- known limitations and live-test gaps; and
+- breaking changes or deprecations.
+
+A release should link the compatibility matrix rather than copying transient live-test claims into permanent marketing language.
+
+## What CI proves
+
+Repository CI proves the deterministic code/test surfaces exercised by the workflow. It does **not** prove authenticated provider UI compatibility, browser rollout compatibility, account/workspace variants, or mobile behavior.
+
+Those claims require live evidence. Keeping these evidence classes separate lets contributors trust a green test suite without mistaking it for a promise about an external provider surface.

--- a/docs/testing/compatibility.md
+++ b/docs/testing/compatibility.md
@@ -2,7 +2,7 @@
 
 Crossdock's browser adapter depends on authenticated provider UI behavior that repository tests cannot prove. This page records **publicly reported, reproducible live-test evidence** without turning anecdotal success into an unsupported compatibility promise.
 
-Use [`public-live-test.md`](public-live-test.md) for the procedure and the repository's live-test issue template for reports.
+Use [`public-live-test.md`](public-live-test.md) for the procedure and the repository's live-test issue template for reports. See [`../releases.md`](../releases.md) for the distinction between experimental, verified, and supported behavior.
 
 ## Status vocabulary
 
@@ -11,7 +11,7 @@ Use [`public-live-test.md`](public-live-test.md) for the procedure and the repos
 - **partial** — some required steps completed but the full path did not.
 - **not tested** — no public evidence has been recorded.
 
-A previous verification does not guarantee compatibility with a later provider UI. Always include the Crossdock ref and test date.
+A previous verification does not guarantee compatibility with a later provider UI. Always include the Crossdock ref and test date. A verified row is dated evidence; it does not by itself promote an integration from experimental to supported.
 
 ## Reported environments
 
@@ -23,11 +23,13 @@ Replace the placeholder row when the first public report is accepted. Keep rows 
 
 ## What counts as a verified path
 
-For **Initial → PR**, the intended PR must exist exactly once, the target change/branch must be correct, the task-record link must be durable, and persisted evidence must match the selected evidence policy.
+For **Initial → PR**, the intended PR must exist exactly once, the target change/branch must be correct, the immutable task record must be durably stored and remotely verifiable, persisted evidence must match the selected evidence policy, and any configured PR-body publication must match the selected publication policy. A `none` publication choice is successful only when the record still exists but Crossdock provenance is absent from that PR surface.
 
-For **PR update**, the expected existing PR head must change, a new task record must be created, a new top-level update comment must link it, and the original PR body must not be rewritten merely for later provenance.
+For **PR update**, the expected existing PR head must change, a new immutable task record must be created and remotely verifiable, and the configured update-publication policy must be honored. With `link`, a new top-level update comment must link the record; with `none`, Crossdock must not create that provenance comment. The original PR body must not be rewritten merely for later provenance.
 
-For **Automatic**, the same durable outcome and safety checks must hold without the manual handoff approval step.
+For **Automatic**, the same durable outcome, privacy choices, publication choices, and safety checks must hold without the manual handoff approval step.
+
+Evidence retention and recovery persistence are independent. A compatibility report that exercises `full`, `hash`, or `omit` should say which durable evidence modes were tested. Recovery behavior should be reported separately when prompt/report memory-only modes are exercised; a deliberately unrecoverable restart is a correct result when the selected policy intentionally discarded bytes that `full`/`hash` evidence later requires.
 
 ## Privacy
 
@@ -37,4 +39,4 @@ Only record environment and result metadata safe for public disclosure. Never co
 
 A matrix update should link a public test report that contains enough non-secret evidence to understand what was exercised. Conflicting results from the same browser/OS/provider combination should remain visible rather than being averaged away; provider account/workspace variants and UI rollouts may matter.
 
-When a provider UI changes materially, do not erase older rows. Their date and Crossdock ref are useful historical compatibility evidence.
+When a provider UI changes materially, do not erase older rows. Their date and Crossdock ref are useful historical compatibility evidence. If newer evidence shows a regression, add the new result and leave the historical row intact.


### PR DESCRIPTION
## Summary
- define pre-1.0 versioning and release-note expectations
- distinguish experimental, verified, and supported integrations
- define provider-UI breakage and re-verification behavior
- document configuration/task-record compatibility and deprecation rules
- correct the compatibility matrix so `link` and `none` publication are both valid verified outcomes
- refresh README status to match the implemented publication/recovery surface

## Why
Contributors and testers need to know what CI proves, what live testing proves, and what Crossdock actually promises before 1.0. The existing compatibility page also still assumed provenance links/comments were mandatory after #50 made those surfaces configurable.

Closes #16.