### PR TITLE
Wire report crash-recovery UI and state through the browser dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The public repository currently contains:
 - a task-record storage adapter boundary with a GitHub-backed adapter;
 - independently configurable prompt/report evidence retention (`full`, `hash`, or `omit`);
 - independently configurable PR-body/update-comment provenance presentation (`link` or `none`) while durable task-record storage remains required by the current handoff path;
-- configurable prompt crash-recovery persistence (`persist` or `memory`) plus provider-report recovery state semantics and shared report-recovery configuration;
+- independently configurable prompt and provider-report crash-recovery persistence (`persist` or `memory`) in the browser dashboard;
 - idempotent immutable-record and update-comment retry handling;
 - a shared configuration resolver with explicit scope precedence;
 - a configurable loopback HTTP handoff service restricted to numeric loopback;
@@ -31,7 +31,7 @@ The public repository currently contains:
 - public live-test, compatibility, architecture, configuration, security, release-policy, development, and contribution documentation; and
 - GitHub Actions validation for the Node/JavaScript surfaces.
 
-The browser adapter currently executes `link` and `none` provenance choices for initial PR descriptions and later update comments. `summary` and committed-file publication remain intentionally unimplemented until their safety/idempotency semantics are complete. Report-recovery browser UI/state wiring is tracked in [#54](https://github.com/seedbed-ai/crossdock/issues/54). The adapter remains fail-closed and experimental until authenticated live compatibility testing establishes current provider behavior.
+The browser adapter currently executes `link` and `none` provenance choices for initial PR descriptions and later update comments. `summary` and committed-file publication remain intentionally unimplemented until their safety/idempotency semantics are complete. The adapter remains fail-closed and experimental until authenticated live compatibility testing establishes current provider behavior.
 
 ## Ways to help right now
 

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -14,11 +14,11 @@ Browser integrations may act inside sessions the user already authenticated, but
 
 Durable task-record evidence and transient browser recovery state are separate data boundaries.
 
-The current browser client can persist active-task state in `chrome.storage.local` to survive dashboard/browser restarts. Prompt plaintext persistence is explicit: `recovery.prompt: persist` allows the prompt in local recovery state, while `recovery.prompt: memory` removes prompt plaintext from both persisted active-task state and persisted dashboard-form state.
+The current browser client can persist active-task state in `chrome.storage.local` to survive dashboard/browser restarts. Prompt plaintext persistence is explicit: `recovery.prompt: persist` allows the prompt in local recovery state, while `recovery.prompt: memory` removes prompt plaintext from both persisted active-task state and persisted dashboard-form state. Report plaintext has an independent boundary: `recovery.report: persist` allows a captured provider report in persisted active-task state, while `recovery.report: memory` keeps it only in live JavaScript state and removes `final_report` from local recovery snapshots.
 
-Memory-only recovery is deliberately lossy across restart. Crossdock must not reconstruct, recapture, or silently persist a missing prompt merely to complete `full` or `hash` durable evidence. If the original prompt bytes are gone and the selected durable evidence still requires them, recovery fails clearly. Durable prompt `omit` may recover without the prompt because no prompt plaintext or digest is required in the final record.
+Memory-only recovery is deliberately lossy across restart. Crossdock must not reconstruct, recapture, silently persist, or downgrade evidence for missing prompt or report bytes merely to complete `full` or `hash` durable evidence. If the original bytes are gone and the corresponding durable evidence still requires them, recovery fails clearly. Durable `omit` may recover without those bytes because no plaintext or digest is required in the final record. Before provider-report capture, restart remains recoverable in either report recovery mode; after capture, a memory-only report is intentionally unavailable following restart.
 
-This setting does not encrypt browser memory and does not yet control report recovery state, history, diagnostics, expiration, or secure OS-backed storage. Those remain separate lifecycle/security boundaries.
+Neither setting encrypts browser memory or controls history, diagnostics, expiration, deletion, or secure OS-backed storage. Those remain separate lifecycle/security boundaries. Both policies are frozen at task submission, so editing a visible selector cannot widen persistence for an active task.
 
 ## GitHub credentials
 

--- a/docs/configuration/model.md
+++ b/docs/configuration/model.md
@@ -83,7 +83,7 @@ For reports, the bytes only become recovery-critical after the provider report h
 
 Changing a visible recovery preference after a task starts must not alter that task's frozen recovery policy. Crossdock never silently turns `memory` into `persist` merely to make recovery succeed.
 
-The shared configuration contract now carries both recovery choices. The current browser UI still exposes prompt recovery only; report-recovery UI/state wiring is the next execution slice. Encrypted/OS-secure recovery storage, retention windows, completed-task history, diagnostics, expiration, and deletion remain separate lifecycle work rather than being inferred from these fields.
+The browser dashboard exposes both choices and freezes them into active-task state at submission. It removes a captured memory-only report from every persisted active-task snapshot while retaining the live copy long enough for ordinary in-page finalization. Legacy and prompt-era active tasks are migrated explicitly to `recovery.report: persist`. Encrypted/OS-secure recovery storage, retention windows, completed-task history, diagnostics, expiration, and deletion remain separate lifecycle work rather than being inferred from these fields.
 
 ## Publication and durable storage are separate
 

--- a/docs/testing/public-live-test.md
+++ b/docs/testing/public-live-test.md
@@ -81,6 +81,7 @@ Set:
 - the prompt evidence policy;
 - the report evidence policy;
 - the prompt recovery policy;
+- the report recovery policy;
 - the initial-PR provenance publication choice; and
 - the update provenance publication choice.
 
@@ -98,6 +99,8 @@ Prompt recovery is a separate local-lifecycle choice:
 - **Memory only** — Crossdock may use the prompt while the live dashboard remains open but must not write the prompt into persisted dashboard or active-task state.
 
 Memory-only recovery intentionally trades restart recovery for lower local retention. If the dashboard/browser restarts and durable prompt evidence is `full` or `hash`, Crossdock must fail clearly because the original prompt bytes are no longer available. With durable prompt evidence `omit`, recovery may continue without prompt content. Changing the visible recovery selector after submission must not widen the already-started task's frozen recovery policy.
+
+Report recovery is independent and uses the same **Persist for restart recovery** and **Memory only** choices. Memory-only applies once the provider report is captured: the live dashboard may finalize with those bytes, but browser-local active-task state must not contain them. A restart before capture remains recoverable. A restart after capture must fail clearly for report evidence `full` or `hash`, while report evidence `omit` may continue without report content.
 
 Publication is another separate choice. The current dashboard supports:
 
@@ -160,7 +163,13 @@ Verify that normal in-page execution can proceed, then inspect only your own loc
 
 For restart behavior, use a second disposable memory-only task. If prompt evidence is `full` or `hash`, restart/reload after submission and verify Crossdock reports that prompt content is unavailable instead of silently recapturing or reconstructing it. If prompt evidence is `omit`, verify recovery can continue without prompt content when the rest of the provider state remains recoverable.
 
-## 10. Exercise no-PR-visible provenance
+## 10. Exercise memory-only report recovery (Thursday)
+
+On Thursday's disposable test run, select **Report crash recovery: Memory only** independently of prompt recovery. First restart the dashboard while the provider task is still running, before report capture, and verify that monitoring can resume. Then complete a separate task without restarting and verify that normal in-page finalization succeeds while persisted active-task snapshots contain no `final_report`. Change the visible report-recovery selector after submission and verify that the task remains frozen to memory-only.
+
+Where provider timing makes the boundary practical to exercise safely, use separate disposable post-capture cases: with durable report evidence `full` and `hash`, restart after capture and verify a clear unavailable-original-bytes failure; with report evidence `omit`, verify recovery continues without report content. Do not trigger provider actions again, recapture a report, manually reconstruct it, or accept an evidence downgrade to rescue these cases.
+
+## 11. Exercise no-PR-visible provenance
 
 After the baseline initial/update flow succeeds, exercise publication independently from durable storage.
 
@@ -177,11 +186,11 @@ As an optional frozen-policy recovery check, start a task with publication set o
 
 The shared configuration schema also reserves `summary` and committed-file publication modes, but the current browser/service path intentionally does not expose or execute those modes yet. Do not treat them as live-test requirements for this adapter.
 
-## 11. Test automatic mode
+## 12. Test automatic mode
 
 After both review-mode flows work, repeat with automatic handoff enabled. The durable result should be equivalent; only the approval transition should differ.
 
-## 12. Failure cases worth reporting
+## 13. Failure cases worth reporting
 
 Useful live-test failures include:
 
@@ -197,6 +206,8 @@ Useful live-test failures include:
 - task recovery switching to a newly edited publication preference instead of its frozen policy;
 - memory-only prompt content appearing in persisted dashboard or active-task state;
 - a memory-only task silently widening prompt retention after a selector change or restart;
+- captured memory-only report content appearing in persisted active-task state;
+- post-capture restart silently recapturing a report, widening report persistence, or downgrading durable evidence;
 - a task record missing because PR-visible publication was disabled;
 - a PR body/comment containing Crossdock provenance despite a `none` publication choice;
 - loopback service failure;

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -50,7 +50,13 @@
           <option value="memory">Keep prompt in memory only</option>
         </select>
       </label>
-      <p class="wide">Evidence settings control the durable task record. Prompt crash recovery is separate: memory-only prevents the prompt from being written to browser local storage, but a browser/dashboard restart cannot recover full or hash prompt evidence because the original prompt bytes are intentionally gone.</p>
+      <label>Report crash recovery
+        <select id="report-recovery">
+          <option value="persist">Persist captured report locally for recovery</option>
+          <option value="memory">Keep captured report in memory only</option>
+        </select>
+      </label>
+      <p class="wide">Evidence settings control the durable task record. Crash recovery is separate: memory-only prevents that plaintext from being written to browser local storage. After a restart, full or hash evidence cannot be completed if the required original bytes were intentionally discarded. Reports are only affected after capture.</p>
       <label>Initial PR provenance
         <select id="change-description-publication">
           <option value="link">Publish task-record link</option>

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -5,9 +5,12 @@ import {
 } from "./publication-client.js";
 import {
   DEFAULT_PROMPT_RECOVERY_MODE,
+  DEFAULT_REPORT_RECOVERY_MODE,
   assertPromptAvailableForRecovery,
+  assertReportAvailableForRecovery,
   migrateActiveTaskRecovery,
   normalizePromptRecoveryMode,
+  normalizeReportRecoveryMode,
   taskStateForLocalPersistence,
 } from "./recovery-client.js";
 import {
@@ -18,7 +21,7 @@ import {
 } from "./service-client.js";
 
 const $ = (id) => document.getElementById(id);
-const fields = ["repository", "issue", "pull-request", "handoff-mode", "service-url", "storage-repository", "storage-branch", "prompt-evidence", "report-evidence", "prompt-recovery", "change-description-publication", "change-comment-publication", "summary", "validation", "prompt"];
+const fields = ["repository", "issue", "pull-request", "handoff-mode", "service-url", "storage-repository", "storage-branch", "prompt-evidence", "report-evidence", "prompt-recovery", "report-recovery", "change-description-publication", "change-comment-publication", "summary", "validation", "prompt"];
 const POLL_MS = 5000;
 let taskState = null;
 let monitoring = false;
@@ -360,7 +363,10 @@ function readEvidencePolicy() {
 }
 
 function readRecoveryPolicy() {
-  return { prompt: normalizePromptRecoveryMode($("prompt-recovery").value) };
+  return {
+    prompt: normalizePromptRecoveryMode($("prompt-recovery").value),
+    report: normalizeReportRecoveryMode($("report-recovery").value),
+  };
 }
 
 function readPublicationPolicy() {
@@ -423,6 +429,7 @@ function parsePrNumber(url, repository) {
 function requireTaskState(mode) {
   if (!taskState?.task_id) throw new Error("no submitted task is active");
   assertPromptAvailableForRecovery(taskState);
+  assertReportAvailableForRecovery(taskState);
   if (mode && taskState.mode !== mode) throw new Error(`active task is ${taskState.mode}, not ${mode}`);
 }
 
@@ -471,6 +478,7 @@ async function restore() {
   }
   if (!$("service-url").value.trim()) $("service-url").value = DEFAULT_SERVICE_URL;
   if (!$("prompt-recovery").value) $("prompt-recovery").value = DEFAULT_PROMPT_RECOVERY_MODE;
+  if (!$("report-recovery").value) $("report-recovery").value = DEFAULT_REPORT_RECOVERY_MODE;
   if (!$("change-description-publication").value) $("change-description-publication").value = DEFAULT_PUBLICATION_POLICY.change_description;
   if (!$("change-comment-publication").value) $("change-comment-publication").value = DEFAULT_PUBLICATION_POLICY.change_comment;
 
@@ -483,6 +491,7 @@ async function restore() {
 
   try {
     assertPromptAvailableForRecovery(taskState);
+    assertReportAvailableForRecovery(taskState);
   } catch (error) {
     setStatus(error.message, true);
     return;

--- a/extension/recovery-client.js
+++ b/extension/recovery-client.js
@@ -12,11 +12,10 @@ export function taskStateForLocalPersistence(taskState) {
   if (taskState == null) return null;
   if (!taskState || typeof taskState !== "object" || Array.isArray(taskState)) throw new TypeError("active task state must be an object");
   const prompt = normalizePromptRecoveryMode(taskState.recovery?.prompt ?? DEFAULT_PROMPT_RECOVERY_MODE);
-  const hasReportPolicy = Object.hasOwn(taskState.recovery ?? {}, "report");
   const report = normalizeReportRecoveryMode(taskState.recovery?.report ?? DEFAULT_REPORT_RECOVERY_MODE);
   const persisted = structuredClone(taskState);
   persisted.recovery = { ...(persisted.recovery ?? {}), prompt };
-  if (hasReportPolicy) persisted.recovery.report = report;
+  persisted.recovery.report = report;
   if (prompt === "memory") delete persisted.prompt;
   if (report === "memory") delete persisted.final_report;
   return persisted;
@@ -25,10 +24,14 @@ export function taskStateForLocalPersistence(taskState) {
 export function migrateActiveTaskRecovery(taskState) {
   if (taskState == null) return { taskState: null, changed: false };
   if (!taskState || typeof taskState !== "object" || Array.isArray(taskState)) throw new TypeError("active task state must be an object");
-  if (!Object.hasOwn(taskState, "recovery")) return { taskState: { ...taskState, recovery: { prompt: DEFAULT_PROMPT_RECOVERY_MODE } }, changed: true };
-  const prompt = normalizePromptRecoveryMode(taskState.recovery?.prompt);
-  if (Object.hasOwn(taskState.recovery, "report")) normalizeReportRecoveryMode(taskState.recovery.report);
-  return { taskState: { ...taskState, recovery: { ...taskState.recovery, prompt } }, changed: false };
+  const recovery = taskState.recovery;
+  if (!Object.hasOwn(taskState, "recovery")) {
+    return { taskState: { ...taskState, recovery: { prompt: DEFAULT_PROMPT_RECOVERY_MODE, report: DEFAULT_REPORT_RECOVERY_MODE } }, changed: true };
+  }
+  const prompt = normalizePromptRecoveryMode(recovery?.prompt);
+  const hasReport = Object.hasOwn(recovery, "report");
+  const report = normalizeReportRecoveryMode(recovery?.report ?? DEFAULT_REPORT_RECOVERY_MODE);
+  return { taskState: { ...taskState, recovery: { ...recovery, prompt, report } }, changed: !hasReport };
 }
 
 export function assertPromptAvailableForRecovery(taskState) {

--- a/tests/dashboard-recovery.test.js
+++ b/tests/dashboard-recovery.test.js
@@ -1,7 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 
-test("memory-only prompt recovery persists neither dashboard nor active-task prompt", async () => {
+test("dashboard exposes report recovery with historical persist default", async () => {
+  const html = await readFile(new URL("../extension/dashboard.html", import.meta.url), "utf8");
+  assert.match(html, /<select id="report-recovery">\s*<option value="persist">/);
+});
+
+test("submission freezes independent memory-only prompt and report recovery", async () => {
   const previous = { document: globalThis.document, chrome: globalThis.chrome, fetch: globalThis.fetch };
   const elements = makeDashboardElements();
   const storage = {};
@@ -14,6 +20,7 @@ test("memory-only prompt recovery persists neither dashboard nor active-task pro
   Object.assign(elements.get("prompt-evidence"), { value: "omit" });
   Object.assign(elements.get("report-evidence"), { value: "omit" });
   Object.assign(elements.get("prompt-recovery"), { value: "memory" });
+  Object.assign(elements.get("report-recovery"), { value: "memory" });
   Object.assign(elements.get("change-description-publication"), { value: "none" });
   Object.assign(elements.get("change-comment-publication"), { value: "none" });
 
@@ -59,7 +66,7 @@ test("memory-only prompt recovery persists neither dashboard nor active-task pro
 
     assert.equal(storage.dashboard.prompt, undefined);
     assert.equal(storage.taskState.prompt, undefined);
-    assert.deepEqual(storage.taskState.recovery, { prompt: "memory" });
+    assert.deepEqual(storage.taskState.recovery, { prompt: "memory", report: "memory" });
     assert.equal(storage.taskState.evidence_policy.prompt, "omit");
     assert.equal(storage.taskState.phase, "ready");
   } finally {
@@ -69,11 +76,70 @@ test("memory-only prompt recovery persists neither dashboard nor active-task pro
   }
 });
 
+test("captured memory-only report stays live for handoff but never enters persisted task state", async () => {
+  const previous = { document: globalThis.document, chrome: globalThis.chrome, fetch: globalThis.fetch };
+  const elements = makeDashboardElements();
+  const storage = {};
+  const persistedTasks = [];
+  const requests = [];
+  for (const [id, value] of Object.entries({
+    repository: "example/repo", "pull-request": "7", "handoff-mode": "review",
+    "service-url": "http://127.0.0.1:3210", "storage-repository": "example/records", "storage-branch": "main",
+    "prompt-evidence": "omit", "report-evidence": "full", "prompt-recovery": "persist", "report-recovery": "memory",
+    "change-description-publication": "none", "change-comment-publication": "none", prompt: "safe test prompt",
+  })) elements.get(id).value = value;
+
+  globalThis.document = { getElementById: (id) => elements.get(id) ?? null, querySelectorAll: () => [] };
+  globalThis.chrome = {
+    runtime: { async sendMessage(message) {
+      if (message.type === "crossdock.submitCodex") return { ok: true, result: { taskUrl: "https://agent.example/tasks/2" } };
+      if (message.type === "crossdock.inspectCodex") return { ok: true, result: { updateBranchAvailable: true } };
+      if (message.type === "crossdock.applyBranchUpdate") return { ok: true, result: { taskUrl: "https://agent.example/tasks/2", report: "private report bytes" } };
+      return { ok: true, result: {} };
+    } },
+    storage: { local: {
+      async get(keys) { const list = Array.isArray(keys) ? keys : [keys]; return Object.fromEntries(list.filter((key) => Object.hasOwn(storage, key)).map((key) => [key, structuredClone(storage[key])])); },
+      async set(values) { Object.assign(storage, structuredClone(values)); if (values.taskState) persistedTasks.push(structuredClone(values.taskState)); },
+      async remove(key) { delete storage[key]; },
+    } },
+  };
+  globalThis.fetch = async (url, init) => {
+    requests.push({ url, init });
+    if (url.endsWith("/pr/snapshot")) return okResponse({ head_sha: requests.filter((call) => call.url.endsWith("/pr/snapshot")).length === 1 ? "old" : "new" });
+    if (url.endsWith("/handoff/update")) return okResponse({ task_record_url: "https://records.example/task" });
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+
+  try {
+    await import(`${new URL("../extension/dashboard.js", import.meta.url).href}?memory-report-live=${Date.now()}`);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await elements.get("submit").listeners.get("click")();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.deepEqual(storage.taskState.recovery, { prompt: "persist", report: "memory" });
+
+    elements.get("report-recovery").value = "persist";
+    await elements.get("report-recovery").listeners.get("change")();
+    await elements.get("finalize-update").listeners.get("click")();
+
+    assert.ok(persistedTasks.every((state) => state.final_report === undefined));
+    assert.ok(persistedTasks.every((state) => state.recovery.report === "memory"));
+    const handoff = requests.find(({ url }) => url.endsWith("/handoff/update"));
+    assert.equal(JSON.parse(handoff.init.body).task.report, "private report bytes");
+    assert.equal(storage.taskState, undefined);
+  } finally {
+    Object.assign(globalThis, previous);
+  }
+});
+
+function okResponse(body) {
+  return { ok: true, status: 200, async json() { return body; } };
+}
+
 function makeDashboardElements() {
   const ids = [
     "open-chatgpt", "open-codex", "open-github", "capture", "submit", "finalize-initial", "finalize-update",
     "repository", "issue", "pull-request", "handoff-mode", "service-url", "storage-repository", "storage-branch",
-    "prompt-evidence", "report-evidence", "prompt-recovery", "change-description-publication", "change-comment-publication",
+    "prompt-evidence", "report-evidence", "prompt-recovery", "report-recovery", "change-description-publication", "change-comment-publication",
     "summary", "validation", "prompt", "status",
   ];
   return new Map(ids.map((id) => [id, {

--- a/tests/dashboard.test.js
+++ b/tests/dashboard.test.js
@@ -119,6 +119,7 @@ test("dashboard restoration keeps recovered update requests on frozen endpoint a
       "prompt-evidence": "full",
       "report-evidence": "full",
       "prompt-recovery": "persist",
+      "report-recovery": "persist",
       "change-description-publication": "none",
       "change-comment-publication": "none",
       summary: "Update summary",
@@ -181,6 +182,8 @@ test("dashboard restoration keeps recovered update requests on frozen endpoint a
     await import(`${new URL("../extension/dashboard.js", import.meta.url).href}?recovery-test=${Date.now()}`);
     await new Promise((resolve) => setTimeout(resolve, 0));
 
+    assert.deepEqual(storage.taskState.recovery, { prompt: "persist", report: "persist" });
+
     elements.get("service-url").value = "http://127.0.0.1:9999";
     elements.get("change-comment-publication").value = "none";
     const finalize = elements.get("finalize-update").listeners.get("click");
@@ -209,7 +212,7 @@ function makeDashboardElements() {
   const ids = [
     "open-chatgpt", "open-codex", "open-github", "capture", "submit", "finalize-initial", "finalize-update",
     "repository", "issue", "pull-request", "handoff-mode", "service-url", "storage-repository", "storage-branch",
-    "prompt-evidence", "report-evidence", "prompt-recovery", "change-description-publication", "change-comment-publication", "summary", "validation", "prompt", "status",
+    "prompt-evidence", "report-evidence", "prompt-recovery", "report-recovery", "change-description-publication", "change-comment-publication", "summary", "validation", "prompt", "status",
   ];
   return new Map(ids.map((id) => [id, {
     value: "",

--- a/tests/recovery-client.test.js
+++ b/tests/recovery-client.test.js
@@ -23,7 +23,7 @@ test("persist mode retains prompt in local recovery state", () => {
   const original = task();
   const stored = taskStateForLocalPersistence(original);
   assert.equal(stored.prompt, "private prompt");
-  assert.deepEqual(stored.recovery, { prompt: "persist" });
+  assert.deepEqual(stored.recovery, { prompt: "persist", report: "persist" });
   assert.notEqual(stored, original);
 });
 
@@ -32,14 +32,14 @@ test("memory mode removes prompt from local recovery state without mutating live
   const stored = taskStateForLocalPersistence(original);
   assert.equal(stored.prompt, undefined);
   assert.equal(original.prompt, "private prompt");
-  assert.deepEqual(stored.recovery, { prompt: "memory" });
+  assert.deepEqual(stored.recovery, { prompt: "memory", report: "persist" });
 });
 
 test("legacy active tasks migrate to historical prompt persistence", () => {
   const original = { task_id: "legacy", prompt: "prompt", phase: "ready" };
   const migrated = migrateActiveTaskRecovery(original);
   assert.equal(migrated.changed, true);
-  assert.deepEqual(migrated.taskState.recovery, { prompt: DEFAULT_PROMPT_RECOVERY_MODE });
+  assert.deepEqual(migrated.taskState.recovery, { prompt: DEFAULT_PROMPT_RECOVERY_MODE, report: "persist" });
   assert.equal(original.recovery, undefined);
 });
 

--- a/tests/report-recovery.test.js
+++ b/tests/report-recovery.test.js
@@ -19,10 +19,10 @@ test("memory-only report is removed only from the persisted clone", () => {
   assert.deepEqual(stored.recovery, { prompt: "persist", report: "memory" });
 });
 
-test("prompt-era active tasks preserve their shape and inherit report persistence semantically", () => {
+test("prompt-era active tasks migrate explicitly to historical report persistence", () => {
   const migrated = migrateActiveTaskRecovery(task({ recovery: { prompt: "memory" } }));
-  assert.equal(migrated.changed, false);
-  assert.deepEqual(migrated.taskState.recovery, { prompt: "memory" });
+  assert.equal(migrated.changed, true);
+  assert.deepEqual(migrated.taskState.recovery, { prompt: "memory", report: DEFAULT_REPORT_RECOVERY_MODE });
   assert.doesNotThrow(() => assertReportAvailableForRecovery(migrated.taskState));
 });
 


### PR DESCRIPTION
### Motivation

- Let users choose whether captured provider report plaintext may be persisted in browser-local recovery state independently from durable report evidence, while preserving historical defaults and prompt-memory behavior. 
- Freeze both prompt and report recovery choices into the active-task at submission so visible edits after submission cannot widen persistence. 
- Ensure legacy/prompt-era active tasks migrate deterministically to `report: persist` and that memory-only report bytes remain available for same-page finalization but are omitted from persisted snapshots. 

### Description

- Add a report crash-recovery selector to the dashboard UI (`extension/dashboard.html`) with the historical default `persist`. 
- Wire report recovery into the dashboard flow (`extension/dashboard.js`): include `report-recovery` in persisted `fields`, capture `readRecoveryPolicy()` with `report`, freeze recovery choices at submission, enforce `assertReportAvailableForRecovery()` during require/restore, and preserve prompt-memory filtering. 
- Update the recovery client (`extension/recovery-client.js`) so `taskStateForLocalPersistence()` removes `final_report` when report recovery is `memory`, and `migrateActiveTaskRecovery()` deterministically migrates legacy/ prompt-era tasks to include `report: persist`. 
- Add and update tests to exercise the end-to-end browser/dashboard behavior and migrations (`tests/dashboard-recovery.test.js`, `tests/recovery-client.test.js`, `tests/report-recovery.test.js`, `tests/dashboard.test.js`). 
- Update docs to reflect implemented behavior and live-test guidance (`docs/configuration/model.md`, `docs/architecture/security-boundaries.md`, `docs/testing/public-live-test.md`) and adjust README language about browser recovery options. 
- Preserve existing durable evidence, publication, and task-record semantics; prompt-memory removal from persisted dashboard form remains unchanged. 

### Testing

- Ran unit/integration test suite with `npm test` and static checks with `npm run check`, both of which completed successfully (all tests passed). 
- New and updated automated tests exercised: UI default for `report: persist`, submission freezing of independent `prompt`/`report` recovery, migration of legacy/prompt-era active tasks to `report: persist`, omission of `final_report` from persisted snapshots when `report: memory` while keeping in-memory report available for same-page finalization, and restart failure semantics for `full`/`hash` evidence when report bytes were discarded. 
- Confirmed code and docs updates compile/validate under the repository check scripts and that no prompt-recovery regressions were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a989940eeb88322ab86b6683761ec20)