### PR TITLE
feat: establish dashboard accessibility baseline

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Crossdock is in early public development. These documents describe the intended 
 - [`testing/public-live-test.md`](testing/public-live-test.md) — provider-neutral desktop live-test steps for public testers.
 - [`testing/compatibility.md`](testing/compatibility.md) — dated public evidence for tested browser/OS/workflow combinations.
 - [`releases.md`](releases.md) — pre-1.0 versioning, compatibility levels, migration/deprecation rules, and release-note expectations.
+- [`accessibility.md`](accessibility.md) — current dashboard accessibility guardrails and manual acceptance checks.
 
 ## Concepts
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,39 @@
+# Accessibility baseline
+
+Crossdock treats accessibility as a release-quality requirement rather than a later visual-polish pass. The current experimental dashboard should remain operable with keyboard-only input, browser zoom/reflow, reduced-motion preferences, screen-reader semantics, and touch-sized controls while authenticated provider compatibility remains separately live-tested.
+
+## Current baseline
+
+For the browser dashboard:
+
+- every interactive control must be keyboard reachable in DOM order;
+- keyboard focus must remain visibly distinguishable with `:focus-visible` styling rather than relying only on color or hover state;
+- buttons, text inputs, and selects use at least a 44 CSS-pixel minimum target height, increasing to 48 pixels in the narrowest layout;
+- form controls have programmatic labels through their containing `label` elements;
+- status changes use a polite live region (`role="status"`, `aria-live="polite"`);
+- grouped navigation/actions have accessible labels;
+- the layout must reflow to one-column task controls and progressively simpler action grids instead of requiring horizontal scrolling at narrow widths;
+- reduced-motion preferences disable Crossdock animation/transition behavior;
+- light/dark rendering uses system colors rather than assuming one fixed color scheme.
+
+These repository checks are guardrails, not proof of conformance. Browser/assistive-technology testing is still required before claiming a supported accessibility level.
+
+## Manual acceptance checks
+
+Before a supported release, exercise the current UI at minimum with:
+
+1. keyboard-only navigation, including visible focus and logical order;
+2. a desktop screen reader on the supported browser/platform combinations;
+3. browser zoom through 200% and narrow-window reflow without loss of controls or required information;
+4. OS/browser reduced-motion preference;
+5. light and dark system themes;
+6. touch/pointer operation at the smallest supported viewport;
+7. error and status transitions to confirm important state changes are announced without excessive repetition.
+
+Record environment-specific results through the normal compatibility/testing process rather than converting a single successful run into a universal support claim.
+
+## Contribution rule
+
+New reusable UI controls must preserve keyboard access, a visible focus state, an accessible name, sufficient target size, and responsive/reflow behavior. If a change introduces animation, it must respect `prefers-reduced-motion`. Changes that cannot be exercised automatically should include the relevant manual accessibility check in the PR validation notes.
+
+Issue #14 tracks the remaining live/manual accessibility validation and broader desktop/mobile baseline work.

--- a/extension/dashboard.css
+++ b/extension/dashboard.css
@@ -2,11 +2,13 @@
 * { box-sizing: border-box; }
 body { margin: 0; min-height: 100vh; background: Canvas; color: CanvasText; }
 button, input, textarea, select { font: inherit; border: 1px solid color-mix(in srgb, CanvasText 22%, transparent); border-radius: 12px; }
-button { min-height: 44px; padding: .7rem 1rem; cursor: pointer; background: color-mix(in srgb, Canvas 88%, CanvasText 12%); color: CanvasText; }
+button, input, select { min-height: 44px; }
+button { padding: .7rem 1rem; cursor: pointer; background: color-mix(in srgb, Canvas 88%, CanvasText 12%); color: CanvasText; }
 button:hover { background: color-mix(in srgb, Canvas 82%, CanvasText 18%); }
 button:disabled { opacity: .55; cursor: wait; }
 button.primary { font-weight: 700; }
 input, textarea, select { width: 100%; padding: .72rem .8rem; background: Canvas; color: CanvasText; }
+button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible { outline: 3px solid currentColor; outline-offset: 3px; }
 textarea { resize: vertical; }
 label { display: grid; gap: .45rem; font-weight: 650; }
 .shell { width: min(1080px, 100%); margin: 0 auto; padding: clamp(1rem, 3vw, 2rem); display: grid; gap: 1.25rem; }
@@ -21,5 +23,5 @@ h1 { margin: 0; font-size: clamp(2rem, 5vw, 3.5rem); letter-spacing: -.045em; }
 .wide { grid-column: 1 / -1; }
 .prompt { display: grid; gap: .5rem; }
 @media (max-width: 700px) { .shell { padding: 1rem; } .hero { align-items: start; flex-direction: column; } #status { width: 100%; } .grid { grid-template-columns: 1fr; } .wide { grid-column: auto; } .surfaces, .actions { grid-template-columns: 1fr 1fr; } }
-@media (max-width: 430px) { .surfaces, .actions { grid-template-columns: 1fr; } button { min-height: 48px; } }
+@media (max-width: 430px) { .surfaces, .actions { grid-template-columns: 1fr; } button, input, select { min-height: 48px; } }
 @media (prefers-reduced-motion: reduce) { *, *::before, *::after { scroll-behavior: auto !important; transition: none !important; animation: none !important; } }

--- a/tests/accessibility-baseline.test.js
+++ b/tests/accessibility-baseline.test.js
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const html = await readFile(new URL("../extension/dashboard.html", import.meta.url), "utf8");
+const css = await readFile(new URL("../extension/dashboard.css", import.meta.url), "utf8");
+
+test("dashboard exposes basic document and live-region semantics", () => {
+  assert.match(html, /<html lang="en">/);
+  assert.match(html, /<meta name="viewport" content="width=device-width,initial-scale=1">/);
+  assert.match(html, /id="status" role="status" aria-live="polite"/);
+  assert.match(html, /<nav class="surfaces" aria-label="Connected work surfaces">/);
+  assert.match(html, /<section class="grid" aria-label="Task setup">/);
+  assert.match(html, /<section class="actions" aria-label="Task actions">/);
+});
+
+test("dashboard keeps form controls programmatically labeled", () => {
+  for (const id of [
+    "repository", "issue", "pull-request", "handoff-mode", "service-url", "storage-repository", "storage-branch",
+    "prompt-evidence", "report-evidence", "prompt-recovery", "report-recovery", "change-description-publication",
+    "change-comment-publication", "summary", "validation", "prompt",
+  ]) {
+    assert.match(html, new RegExp(`<label[^>]*>[\\s\\S]*?(?:<input|<select|<textarea) id="${id}"`), `${id} should remain inside a label`);
+  }
+});
+
+test("dashboard CSS preserves focus, target-size, reflow, and reduced-motion guardrails", () => {
+  assert.match(css, /:focus-visible/);
+  assert.match(css, /outline: 3px solid currentColor/);
+  assert.match(css, /button, input, select \{ min-height: 44px; \}/);
+  assert.match(css, /@media \(max-width: 430px\)/);
+  assert.match(css, /min-height: 48px/);
+  assert.match(css, /@media \(prefers-reduced-motion: reduce\)/);
+  assert.match(css, /grid-template-columns: 1fr/);
+});


### PR DESCRIPTION
## Summary
- define the first public accessibility baseline and manual acceptance checks
- add explicit keyboard focus visibility for dashboard controls
- guarantee minimum control target heights and preserve larger narrow-screen targets
- add deterministic regression guards for document semantics, labels, live-region status, focus, reflow, and reduced motion
- link the baseline from the documentation index

## Scope
This establishes repository-level guardrails for the experimental dashboard. It does not claim WCAG conformance or close the need for real browser/screen-reader/touch/zoom testing across supported platforms.

## Validation
GitHub Actions: `npm test` and `npm run check`.

Relates to #14.