### PR TITLE
Expose committed-file provenance controls in the browser dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The public repository currently contains:
 - public live-test, compatibility, architecture, configuration, security, release-policy, development, and contribution documentation; and
 - GitHub Actions validation for the Node/JavaScript surfaces.
 
-The core and loopback service execute explicit GitHub committed-file provenance destinations with create-or-identical, no-overwrite verification. The browser adapter currently executes `link` and `none` provenance choices only for initial PR descriptions and later update comments; it does not expose committed-file configuration and remains fail-closed for that surface. `summary` also remains unimplemented. The adapter remains fail-closed and experimental until authenticated live compatibility testing establishes current provider behavior.
+The core and loopback service execute explicit GitHub committed-file provenance destinations with create-or-identical, no-overwrite verification. The browser dashboard exposes that optional destination with explicit presentation, repository, branch, and path-template controls alongside independent `link` and `none` choices for initial PR descriptions and later update comments. PR-body/comment `summary` remains unimplemented. The adapter remains fail-closed and experimental until authenticated live compatibility testing establishes current provider behavior.
 
 ## Ways to help right now
 

--- a/docs/configuration/model.md
+++ b/docs/configuration/model.md
@@ -128,7 +128,7 @@ The core and loopback service execute the GitHub destination only after the immu
 
 Committed-file publication never copies prompt/report plaintext, prompt/report hashes, task-record bytes, execution reports, session data, or credentials. Enabling it does not change either evidence mode or grant another evidence-publication permission.
 
-The browser dashboard does not expose committed-file settings yet and its browser policy adapter remains explicitly fail-closed when one is configured. The dashboard does not infer a destination from the target or task-record repository; browser support requires a future explicit UI for presentation, repository, branch, and path template.
+The browser dashboard exposes committed-file publication as an optional control that defaults to disabled. Selecting `link` or `reference` requires the user to enter the GitHub repository, branch, and path template explicitly; the dashboard never derives them from the target repository, task-record storage, current PR, or provider state. The complete normalized policy is frozen into active-task state at submission, so later preference edits and restart recovery cannot redirect an active task. Older active-task publication objects migrate with `committed_file: null` and no inferred destination.
 
 ## Loopback service URL
 

--- a/docs/testing/public-live-test.md
+++ b/docs/testing/public-live-test.md
@@ -83,7 +83,8 @@ Set:
 - the prompt recovery policy;
 - the report recovery policy;
 - the initial-PR provenance publication choice; and
-- the update provenance publication choice.
+- the update provenance publication choice; and
+- optionally, committed-file provenance with an explicit presentation, repository, branch, and path template containing `{task_id}`.
 
 Prompt and report evidence are independent. Current options are:
 
@@ -184,13 +185,19 @@ For a new disposable task, choose **Publish no Crossdock provenance** for the ap
 
 As an optional frozen-policy recovery check, start a task with publication set one way, then change the visible selector before finalization. The active task must use the policy captured at submission rather than the newly edited preference.
 
-The shared configuration schema also reserves `summary` and committed-file publication modes, but the current browser/service path intentionally does not expose or execute those modes yet. Do not treat them as live-test requirements for this adapter.
+PR-body/comment `summary` remains reserved but unimplemented; do not treat it as a live-test option.
 
-## 12. Test automatic mode
+## 12. Optional committed-file exercise (Thursday)
+
+For Thursday's disposable run, select **Link** or **Reference** under **Committed-file provenance** and explicitly enter a private or otherwise appropriate disposable GitHub repository, branch, and repository-relative path such as `crossdock/{task_id}.md`. Do not reuse sensitive evidence or assume the target/task-record repository is the destination.
+
+Verify that the file is created at the exact configured repository, branch, and resolved path. Its deterministic link/reference content must contain no prompt or report evidence. Retry or recover the handoff and confirm create-or-identical behavior neither overwrites nor duplicates the file. After submitting another task, change all visible committed-file fields before finalization and confirm the active task still publishes only to its original frozen destination. A missing or partial destination must fail before coding-agent delegation or source mutation.
+
+## 13. Test automatic mode
 
 After both review-mode flows work, repeat with automatic handoff enabled. The durable result should be equivalent; only the approval transition should differ.
 
-## 13. Failure cases worth reporting
+## 14. Failure cases worth reporting
 
 Useful live-test failures include:
 

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -61,7 +61,13 @@
       <label>Update provenance
         <select id="change-comment-publication"><option value="link">Publish task-record comment</option><option value="none">Publish no Crossdock provenance</option></select>
       </label>
-      <p class="wide">Publication is separate from task-record storage. Choosing no PR-visible provenance does not disable the configured durable task record. These choices are frozen when a task starts so recovery cannot silently change publication behavior.</p>
+      <label>Committed-file provenance
+        <select id="committed-file-publication"><option value="none">Disabled</option><option value="link">Link</option><option value="reference">Reference</option></select>
+      </label>
+      <label>Provenance file repository <input id="committed-file-repository" placeholder="owner/repo" autocomplete="off" disabled></label>
+      <label>Provenance file branch <input id="committed-file-branch" autocomplete="off" disabled></label>
+      <label class="wide">Provenance file path template <input id="committed-file-path-template" placeholder="provenance/{task_id}.md" autocomplete="off" disabled></label>
+      <p class="wide">Committed-file provenance is optional. Enabling it requires an explicit repository, branch, and path template containing <code>{task_id}</code>; no destination is inferred. Publication is separate from task-record storage. These choices are frozen when a task starts.</p>
       <label class="wide">PR / update summary <textarea id="summary" rows="3" placeholder="What changed and why?"></textarea></label>
       <label class="wide">Validation <textarea id="validation" rows="3" placeholder="One result per line"></textarea></label>
     </section>

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -21,7 +21,7 @@ import {
 } from "./service-client.js";
 
 const $ = (id) => document.getElementById(id);
-const fields = ["repository", "issue", "pull-request", "handoff-mode", "service-url", "storage-repository", "storage-branch", "prompt-evidence", "report-evidence", "prompt-recovery", "report-recovery", "change-description-publication", "change-comment-publication", "summary", "validation", "prompt"];
+const fields = ["repository", "issue", "pull-request", "handoff-mode", "service-url", "storage-repository", "storage-branch", "prompt-evidence", "report-evidence", "prompt-recovery", "report-recovery", "change-description-publication", "change-comment-publication", "committed-file-publication", "committed-file-repository", "committed-file-branch", "committed-file-path-template", "summary", "validation", "prompt"];
 const POLL_MS = 5000;
 let taskState = null;
 let monitoring = false;
@@ -101,6 +101,7 @@ $("finalize-update").addEventListener("click", run(async () => {
 for (const id of fields.filter((id) => id !== "prompt")) {
   $(id).addEventListener("change", () => void persist());
 }
+$("committed-file-publication").addEventListener("change", updateCommittedFileControls);
 
 async function monitorTask() {
   if (monitoring || !taskState) return;
@@ -370,11 +371,23 @@ function readRecoveryPolicy() {
 }
 
 function readPublicationPolicy() {
+  const presentation = $("committed-file-publication").value;
   return normalizeBrowserPublicationPolicy({
     change_description: $("change-description-publication").value,
     change_comment: $("change-comment-publication").value,
-    committed_file: null,
+    committed_file: presentation === "none" ? null : {
+      presentation,
+      adapter: "github",
+      repository: $("committed-file-repository").value.trim(),
+      branch: $("committed-file-branch").value.trim(),
+      path_template: $("committed-file-path-template").value.trim(),
+    },
   });
+}
+
+function updateCommittedFileControls() {
+  const disabled = $("committed-file-publication").value === "none";
+  for (const id of ["committed-file-repository", "committed-file-branch", "committed-file-path-template"]) $(id).disabled = disabled;
 }
 
 function requireServiceUrl() {
@@ -481,6 +494,8 @@ async function restore() {
   if (!$("report-recovery").value) $("report-recovery").value = DEFAULT_REPORT_RECOVERY_MODE;
   if (!$("change-description-publication").value) $("change-description-publication").value = DEFAULT_PUBLICATION_POLICY.change_description;
   if (!$("change-comment-publication").value) $("change-comment-publication").value = DEFAULT_PUBLICATION_POLICY.change_comment;
+  if (!$("committed-file-publication").value) $("committed-file-publication").value = "none";
+  updateCommittedFileControls();
 
   const serviceMigration = migrateActiveTaskServiceUrl(stored.taskState ?? null);
   const publicationMigration = migrateActiveTaskPublication(serviceMigration.taskState);

--- a/extension/publication-client.js
+++ b/extension/publication-client.js
@@ -5,6 +5,7 @@ export const DEFAULT_PUBLICATION_POLICY = Object.freeze({
 });
 
 const SUPPORTED_PRESENTATIONS = new Set(["link", "none"]);
+const COMMITTED_FILE_PRESENTATIONS = new Set(["link", "reference"]);
 
 /**
  * Normalize only publication modes the current browser/service path can honor.
@@ -20,12 +21,38 @@ export function normalizeBrowserPublicationPolicy(value) {
   for (const field of ["change_description", "change_comment"]) {
     if (!SUPPORTED_PRESENTATIONS.has(value[field])) throw new Error(`${field} publication must be link or none in the current browser adapter`);
   }
-  if (value.committed_file != null) throw new Error("committed-file publication is not supported by the current browser adapter");
+  const committedFile = normalizeCommittedFile(value.committed_file);
 
   return Object.freeze({
     change_description: value.change_description,
     change_comment: value.change_comment,
-    committed_file: null,
+    committed_file: committedFile,
+  });
+}
+
+function normalizeCommittedFile(value) {
+  if (value == null) return null;
+  if (typeof value !== "object" || Array.isArray(value)) throw new TypeError("committed_file must be an object or null");
+  const allowed = new Set(["presentation", "adapter", "repository", "branch", "path_template"]);
+  for (const key of Object.keys(value)) if (!allowed.has(key)) throw new Error(`committed_file contains unknown field: ${key}`);
+  if (!COMMITTED_FILE_PRESENTATIONS.has(value.presentation)) throw new Error("committed_file.presentation must be link or reference");
+  if (value.adapter !== "github") throw new Error(`committed_file.adapter is unsupported: ${value.adapter}`);
+  if (typeof value.repository !== "string" || !/^[^/\s]+\/[^/\s]+$/.test(value.repository)) throw new Error("committed_file.repository must be owner/repo");
+  if (typeof value.branch !== "string" || !value.branch.trim()) throw new Error("committed_file.branch is required");
+  if (typeof value.path_template !== "string" || !value.path_template.trim()) throw new Error("committed_file.path_template is required");
+
+  const pathTemplate = value.path_template.trim();
+  const segments = pathTemplate.split("/");
+  if (pathTemplate.startsWith("/") || pathTemplate.endsWith("/") || pathTemplate.includes("\\") || pathTemplate.includes("\0") || pathTemplate.replaceAll("{task_id}", "").includes("{") || pathTemplate.replaceAll("{task_id}", "").includes("}") || segments.some((part) => !part || part === "." || part === "..")) {
+    throw new Error("committed_file.path_template must be a safe repository-relative path without unresolved placeholders");
+  }
+  if (!pathTemplate.includes("{task_id}")) throw new Error("committed_file.path_template must include {task_id}");
+  return Object.freeze({
+    presentation: value.presentation,
+    adapter: "github",
+    repository: value.repository,
+    branch: value.branch.trim(),
+    path_template: pathTemplate,
   });
 }
 
@@ -40,8 +67,11 @@ export function migrateActiveTaskPublication(taskState) {
     };
   }
 
+  const legacyPublication = !Object.hasOwn(taskState.publication ?? {}, "committed_file")
+    ? { ...taskState.publication, committed_file: null }
+    : taskState.publication;
   return {
-    taskState: { ...taskState, publication: normalizeBrowserPublicationPolicy(taskState.publication) },
-    changed: false,
+    taskState: { ...taskState, publication: normalizeBrowserPublicationPolicy(legacyPublication) },
+    changed: legacyPublication !== taskState.publication,
   };
 }

--- a/tests/accessibility-baseline.test.js
+++ b/tests/accessibility-baseline.test.js
@@ -19,6 +19,7 @@ test("dashboard keeps form controls programmatically labeled", () => {
     "repository", "issue", "pull-request", "handoff-mode", "service-url", "storage-repository", "storage-branch",
     "prompt-evidence", "report-evidence", "prompt-recovery", "report-recovery", "change-description-publication",
     "change-comment-publication", "summary", "validation", "prompt",
+    "committed-file-publication", "committed-file-repository", "committed-file-branch", "committed-file-path-template",
   ]) {
     assert.match(html, new RegExp(`<label[^>]*>[\\s\\S]*?(?:<input|<select|<textarea) id="${id}"`), `${id} should remain inside a label`);
   }

--- a/tests/dashboard-recovery.test.js
+++ b/tests/dashboard-recovery.test.js
@@ -23,6 +23,10 @@ test("submission freezes independent memory-only prompt and report recovery", as
   Object.assign(elements.get("report-recovery"), { value: "memory" });
   Object.assign(elements.get("change-description-publication"), { value: "none" });
   Object.assign(elements.get("change-comment-publication"), { value: "none" });
+  Object.assign(elements.get("committed-file-publication"), { value: "reference" });
+  Object.assign(elements.get("committed-file-repository"), { value: "example/provenance" });
+  Object.assign(elements.get("committed-file-branch"), { value: "records" });
+  Object.assign(elements.get("committed-file-path-template"), { value: "crossdock/{task_id}.md" });
 
   globalThis.document = {
     getElementById(id) { return elements.get(id) ?? null; },
@@ -68,6 +72,16 @@ test("submission freezes independent memory-only prompt and report recovery", as
     assert.equal(storage.taskState.prompt, undefined);
     assert.deepEqual(storage.taskState.recovery, { prompt: "memory", report: "memory" });
     assert.equal(storage.taskState.evidence_policy.prompt, "omit");
+    assert.deepEqual(storage.taskState.publication.committed_file, {
+      presentation: "reference", adapter: "github", repository: "example/provenance", branch: "records", path_template: "crossdock/{task_id}.md",
+    });
+    elements.get("committed-file-publication").value = "link";
+    elements.get("committed-file-repository").value = "changed/destination";
+    elements.get("committed-file-branch").value = "changed";
+    elements.get("committed-file-path-template").value = "changed/{task_id}.md";
+    assert.deepEqual(storage.taskState.publication.committed_file, {
+      presentation: "reference", adapter: "github", repository: "example/provenance", branch: "records", path_template: "crossdock/{task_id}.md",
+    });
     assert.equal(storage.taskState.phase, "ready");
   } finally {
     globalThis.document = previous.document;
@@ -139,7 +153,7 @@ function makeDashboardElements() {
   const ids = [
     "open-chatgpt", "open-codex", "open-github", "capture", "submit", "finalize-initial", "finalize-update",
     "repository", "issue", "pull-request", "handoff-mode", "service-url", "storage-repository", "storage-branch",
-    "prompt-evidence", "report-evidence", "prompt-recovery", "report-recovery", "change-description-publication", "change-comment-publication",
+    "prompt-evidence", "report-evidence", "prompt-recovery", "report-recovery", "change-description-publication", "change-comment-publication", "committed-file-publication", "committed-file-repository", "committed-file-branch", "committed-file-path-template",
     "summary", "validation", "prompt", "status",
   ];
   return new Map(ids.map((id) => [id, {

--- a/tests/dashboard.test.js
+++ b/tests/dashboard.test.js
@@ -12,6 +12,7 @@ import {
   postServiceJson,
   resolveServiceUrl,
 } from "../extension/service-client.js";
+import { readFile } from "node:fs/promises";
 
 function okResponse(body = { ok: true }) {
   return {
@@ -24,6 +25,14 @@ function okResponse(body = { ok: true }) {
 test("browser service URL accepts explicit port 80 consistently", () => {
   assert.equal(normalizeServiceUrl("http://127.0.0.1:80"), "http://127.0.0.1:80");
   assert.equal(normalizeServiceUrl("http://127.0.0.1:8787/"), "http://127.0.0.1:8787");
+});
+
+test("dashboard defaults committed-file publication to disabled without implicit values", async () => {
+  const html = await readFile(new URL("../extension/dashboard.html", import.meta.url), "utf8");
+  assert.match(html, /<select id="committed-file-publication"><option value="none">Disabled<\/option>/);
+  assert.match(html, /id="committed-file-repository"[^>]*disabled/);
+  assert.match(html, /id="committed-file-branch"[^>]*disabled/);
+  assert.match(html, /id="committed-file-path-template" placeholder="provenance\/\{task_id\}\.md"[^>]*disabled/);
 });
 
 test("browser service URL rejects non-loopback and decorated destinations", () => {
@@ -59,7 +68,7 @@ test("existing active task endpoint is normalized without reading a new preferen
   assert.equal(resolveServiceUrl({ taskState: migrated.taskState, preference: "http://127.0.0.1:9999" }), "http://127.0.0.1:8787");
 });
 
-test("browser publication policy supports only currently executable link and none modes", () => {
+test("browser publication policy supports PR modes and explicit committed-file destinations", () => {
   assert.deepEqual(normalizeBrowserPublicationPolicy({
     change_description: "none",
     change_comment: "link",
@@ -70,7 +79,24 @@ test("browser publication policy supports only currently executable link and non
     committed_file: null,
   });
   assert.throws(() => normalizeBrowserPublicationPolicy({ change_description: "summary", change_comment: "link", committed_file: null }), /link or none/);
-  assert.throws(() => normalizeBrowserPublicationPolicy({ change_description: "link", change_comment: "link", committed_file: { presentation: "reference" } }), /committed-file/);
+  for (const presentation of ["link", "reference"]) {
+    assert.deepEqual(normalizeBrowserPublicationPolicy({
+      change_description: "link", change_comment: "none",
+      committed_file: { presentation, adapter: "github", repository: "example/provenance", branch: "records", path_template: "crossdock/{task_id}.md" },
+    }).committed_file, { presentation, adapter: "github", repository: "example/provenance", branch: "records", path_template: "crossdock/{task_id}.md" });
+  }
+});
+
+test("browser committed-file configuration fails closed", () => {
+  const valid = { presentation: "link", adapter: "github", repository: "example/provenance", branch: "main", path_template: "records/{task_id}.md" };
+  const policy = (committed_file) => ({ change_description: "link", change_comment: "link", committed_file });
+  for (const committed_file of [
+    { ...valid, presentation: "summary" }, { ...valid, adapter: "gitlab" }, { ...valid, repository: "" },
+    { ...valid, branch: "" }, { ...valid, path_template: "" }, { ...valid, path_template: "records/task.md" },
+    { ...valid, path_template: "/records/{task_id}.md" }, { ...valid, path_template: "../{task_id}.md" },
+    { ...valid, path_template: "records\\{task_id}.md" }, { ...valid, path_template: "records//{task_id}.md" },
+    { ...valid, path_template: "records/{other}/{task_id}.md" },
+  ]) assert.throws(() => normalizeBrowserPublicationPolicy(policy(committed_file)));
 });
 
 test("legacy active tasks migrate to historical link publication behavior", () => {
@@ -87,6 +113,12 @@ test("existing active task publication is frozen and validated", () => {
   assert.equal(migrated.changed, false);
   assert.deepEqual(migrated.taskState.publication, publication);
   assert.throws(() => migrateActiveTaskPublication({ task_id: "task-1", publication: { ...publication, change_comment: "summary" } }), /link or none/);
+});
+
+test("older publication objects migrate without inferring committed-file destination", () => {
+  const migrated = migrateActiveTaskPublication({ task_id: "task-1", repository: "target/repo", storage: { repository: "records/repo" }, publication: { change_description: "link", change_comment: "none" } });
+  assert.equal(migrated.changed, true);
+  assert.equal(migrated.taskState.publication.committed_file, null);
 });
 
 test("service client uses frozen task endpoint after preference changes", async () => {
@@ -122,6 +154,10 @@ test("dashboard restoration keeps recovered update requests on frozen endpoint a
       "report-recovery": "persist",
       "change-description-publication": "none",
       "change-comment-publication": "none",
+      "committed-file-publication": "reference",
+      "committed-file-repository": "visible/changed",
+      "committed-file-branch": "changed",
+      "committed-file-path-template": "changed/{task_id}.md",
       summary: "Update summary",
       validation: "tests passed",
       prompt: "Update the branch",
@@ -134,7 +170,7 @@ test("dashboard restoration keeps recovered update requests on frozen endpoint a
       handoff_mode: "review",
       evidence_policy: { prompt: "full", report: "full" },
       recovery: { prompt: "persist" },
-      publication: { change_description: "link", change_comment: "link", committed_file: null },
+      publication: { change_description: "link", change_comment: "link", committed_file: { presentation: "link", adapter: "github", repository: "frozen/provenance", branch: "records", path_template: "tasks/{task_id}.md" } },
       repository: "example/repo",
       service_url: "http://127.0.0.1:8787",
       storage: { repository: "example/records", branch: "main" },
@@ -186,6 +222,10 @@ test("dashboard restoration keeps recovered update requests on frozen endpoint a
 
     elements.get("service-url").value = "http://127.0.0.1:9999";
     elements.get("change-comment-publication").value = "none";
+    elements.get("committed-file-publication").value = "reference";
+    elements.get("committed-file-repository").value = "another/destination";
+    elements.get("committed-file-branch").value = "other";
+    elements.get("committed-file-path-template").value = "other/{task_id}.md";
     const finalize = elements.get("finalize-update").listeners.get("click");
     assert.equal(typeof finalize, "function");
     await finalize();
@@ -198,7 +238,7 @@ test("dashboard restoration keeps recovered update requests on frozen endpoint a
     assert.deepEqual(JSON.parse(handoff.init.body).publication, {
       change_description: "link",
       change_comment: "link",
-      committed_file: null,
+      committed_file: { presentation: "link", adapter: "github", repository: "frozen/provenance", branch: "records", path_template: "tasks/{task_id}.md" },
     });
     assert.equal(storage.taskState, undefined);
   } finally {
@@ -212,7 +252,7 @@ function makeDashboardElements() {
   const ids = [
     "open-chatgpt", "open-codex", "open-github", "capture", "submit", "finalize-initial", "finalize-update",
     "repository", "issue", "pull-request", "handoff-mode", "service-url", "storage-repository", "storage-branch",
-    "prompt-evidence", "report-evidence", "prompt-recovery", "report-recovery", "change-description-publication", "change-comment-publication", "summary", "validation", "prompt", "status",
+    "prompt-evidence", "report-evidence", "prompt-recovery", "report-recovery", "change-description-publication", "change-comment-publication", "committed-file-publication", "committed-file-repository", "committed-file-branch", "committed-file-path-template", "summary", "validation", "prompt", "status",
   ];
   return new Map(ids.map((id) => [id, {
     value: "",


### PR DESCRIPTION
### Motivation

- Make the committed-file provenance publication capability available from the browser dashboard while preserving explicit-destination, privacy, recovery, and frozen-task-state guarantees.
- Ensure the browser UI remains opt-in and fail-closed, never inferring a destination from the target repository, task-record storage, PR context, or provider/session state.

### Description

- Add a new optional UI block in `extension/dashboard.html` for "Committed-file provenance" with `Disabled | Link | Reference` presentation and explicit destination fields `committed-file-repository`, `committed-file-branch`, and `committed-file-path-template` that are disabled by default.
- Read, normalize, and freeze the complete committed-file object at submission in `extension/dashboard.js` and ensure those frozen values are persisted as dashboard preferences but are applied only to the active task state sent through existing handoff calls.
- Extend `extension/publication-client.js` with strict browser-side normalization/validation for committed-file destinations (presentation, adapter, owner/repo, branch, repository-relative safe path containing `{task_id}`) and add legacy migration logic to normalize older publication objects to `committed_file: null` without inferring destinations.
- Update docs and tests to cover UI defaults, validation, normalization, freezing, recovery preservation, legacy migration, and handoff payload forwarding.

### Privacy / safety

Committed-file publication remains disabled by default. Enabling it requires an explicit presentation, repository, branch, and path template. No destination is inferred, and prompt/report evidence remains governed independently.

### Testing

- `npm test` — 146 passing tests
- `npm run check`
- `git diff --check`
- exact-head GitHub Actions CI green

Closes #62. Relates to #44, #8, and #19.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a98a219adec8322a30ba554aabd225b)