### PR TITLE
docs: reconcile roadmap with live-test candidate

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,53 +7,59 @@ Crossdock is pre-release. The public sequence is capability-based rather than da
 The public repository now has:
 
 - a migrated/de-Seedbed deterministic handoff and task-record core;
-- AGPL-3.0-or-later licensing plus public contribution, conduct, support, security, testing, and architecture documentation;
-- protected-branch CI and contributor issue/PR infrastructure;
+- AGPL-3.0-or-later licensing plus public contribution, conduct, support, security, testing, troubleshooting, and architecture documentation;
+- protected-branch CI, dependency-free Markdown link validation, and contributor issue/PR infrastructure;
 - an explicit shared configuration model with scoped precedence;
 - a task-record storage adapter boundary with GitHub as the first implementation;
 - automatic and review-before-handoff modes;
 - configurable loopback service endpoint handling;
 - independently configurable durable prompt/report evidence (`full`, `hash`, `omit`);
-- configurable `link`/`none` provenance presentation on the currently implemented PR-body/update-comment surfaces;
-- prompt recovery persistence controls plus provider-report recovery state semantics and shared report-recovery configuration;
-- provider-neutral work-item intents and capability discovery/preflight;
+- independently configurable prompt/report crash recovery (`persist`, `memory`) in the browser, frozen per active task;
+- configurable `link`/`none` provenance presentation on PR-body/update-comment surfaces;
+- explicit GitHub committed-file provenance publication (`link`, `reference`) in core/service and browser UI, with create-or-identical/no-overwrite verification and no inferred destination;
+- a privacy-safe Active task view for operational recovery state;
+- provider-neutral work-item intents and capability preflight;
+- browser work-intent validation/frozen state that fails closed for unsupported or tampered intents;
+- provider-neutral review request and terminal result contracts pinned to exact source/change/version identity;
 - accepted v3 durable-record semantics plus an isolated experimental codec for review, investigation, remediation, verification, publication, and lineage; and
 - an explicit pre-1.0 release/compatibility policy distinguishing experimental, verified, and supported behavior.
 
-These foundations are not a claim that the authenticated browser path is supported. External-provider behavior still requires dated live evidence.
+These foundations are not a claim that the authenticated browser path is supported. The current Codex browser adapter advertises only experimental `implement`; external-provider behavior still requires dated live evidence.
 
 ## Current workflow frontier
 
-- complete browser execution wiring for report recovery policy ([#54](https://github.com/seedbed-ai/crossdock/issues/54));
-- collect independent ChatGPT → Codex → GitHub live-test evidence and compatibility results ([#28](https://github.com/seedbed-ai/crossdock/issues/28));
+- collect independent ChatGPT → Codex → GitHub implementation-path live-test evidence and compatibility results ([#28](https://github.com/seedbed-ai/crossdock/issues/28));
 - harden browser/provider recovery after live failures and UI changes ([#11](https://github.com/seedbed-ai/crossdock/issues/11));
-- continue transient-data lifecycle controls beyond prompt/report active-task recovery ([#19](https://github.com/seedbed-ai/crossdock/issues/19));
-- expand task-record storage beyond the first GitHub-backed adapter ([#7](https://github.com/seedbed-ai/crossdock/issues/7)); and
-- complete configurable publication destinations beyond current PR `link`/`none` behavior ([#44](https://github.com/seedbed-ai/crossdock/issues/44)).
+- continue transient-data lifecycle controls beyond active-task prompt/report recovery ([#19](https://github.com/seedbed-ai/crossdock/issues/19));
+- expand task-record storage beyond the first GitHub-backed adapter ([#7](https://github.com/seedbed-ai/crossdock/issues/7));
+- complete publication semantics beyond implemented PR `link`/`none` and committed-file `link`/`reference`, especially PR-body/comment `summary` and v3 publication/artifact integration ([#44](https://github.com/seedbed-ai/crossdock/issues/44)); and
+- keep configuration/import-export, secret placement, packaging presentation, and broader lifecycle settings explicit rather than expanding them opportunistically during the live-test candidate window ([#8](https://github.com/seedbed-ai/crossdock/issues/8)).
 
 ## Agent workflows
 
-- first-class persisted code-review work items ([#29](https://github.com/seedbed-ai/crossdock/issues/29));
-- review focus/guidance, reviewed-commit identity, and durable review/comment/thread linkage;
+- first-class executable code-review work items ([#29](https://github.com/seedbed-ai/crossdock/issues/29));
+- implement a real provider adapter path for `review` using the landed provider-neutral request/result contracts without falling back to implementation semantics;
+- review focus/guidance, reviewed-version identity, and durable review/comment/thread linkage;
 - review finding → remediation → re-review lineage;
+- runtime/provider capability discovery where supported and durable recording of the capability path actually used ([#38](https://github.com/seedbed-ai/crossdock/issues/38));
 - investigation/CI-diagnosis and remediation workflows;
 - parallel task families where providers support independent concurrent work;
 - scheduled/repeatable agent work where Crossdock contributes durable state and provenance;
 - image/screenshot-assisted and security-specific workflows only through explicit advertised adapter capabilities; and
-- capability discovery/unsupported-workflow checks at every provider execution boundary ([#38](https://github.com/seedbed-ai/crossdock/issues/38)).
+- never treat an AI review result as human approval or merge authority.
 
 ## User experience
 
 - responsive desktop workspace ([#3](https://github.com/seedbed-ai/crossdock/issues/3));
 - phone-first mobile workflow ([#4](https://github.com/seedbed-ai/crossdock/issues/4));
-- accessibility baseline ([#14](https://github.com/seedbed-ai/crossdock/issues/14));
-- status/error/recovery and task-history UX ([#15](https://github.com/seedbed-ai/crossdock/issues/15)); and
+- complete live/manual accessibility validation on top of the current executable baseline ([#14](https://github.com/seedbed-ai/crossdock/issues/14));
+- expand status/error/recovery into deliberate task-history and retention UX without creating an implicit new evidence store ([#15](https://github.com/seedbed-ai/crossdock/issues/15), [#19](https://github.com/seedbed-ai/crossdock/issues/19)); and
 - installation/onboarding flow once distribution architecture is selected.
 
 ## Integration hardening
 
 - live validation and hardening of the browser extension/service boundary;
-- ChatGPT/Codex adapter compatibility evidence;
+- ChatGPT/Codex adapter compatibility evidence tied to exact tested versions and work intent;
 - GitHub authentication and least-privilege setup;
 - compatibility fixtures and provider-change recovery; and
 - preference for supported provider APIs/SDKs where available while retaining isolated fail-closed browser adapters for unsupported boundaries.


### PR DESCRIPTION
## Summary

Bring the roadmap forward from its pre-report-recovery state to the current live-test candidate:

- remove closed #54 from the active frontier;
- record independent prompt/report recovery and Active task state as landed;
- record browser-exposed committed-file provenance as landed;
- record frozen/fail-closed work-intent behavior;
- record provider-neutral review request/result contracts without claiming browser review execution;
- keep authenticated implementation-path evidence as the immediate frontier;
- narrow #19/#44/#38/#29 to their actual remaining work.

Docs-only; no runtime behavior changes.

Closes #74.