### PR TITLE
ui: add Seedbed footer

### DIFF
--- a/extension/dashboard.css
+++ b/extension/dashboard.css
@@ -8,9 +8,10 @@ button:hover { background: color-mix(in srgb, Canvas 82%, CanvasText 18%); }
 button:disabled { opacity: .55; cursor: wait; }
 button.primary { font-weight: 700; }
 input, textarea, select { width: 100%; padding: .72rem .8rem; background: Canvas; color: CanvasText; }
-button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible { outline: 3px solid currentColor; outline-offset: 3px; }
+button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible, a:focus-visible { outline: 3px solid currentColor; outline-offset: 3px; }
 textarea { resize: vertical; }
 label { display: grid; gap: .45rem; font-weight: 650; }
+a { color: inherit; text-underline-offset: .16em; }
 .shell { width: min(1080px, 100%); margin: 0 auto; padding: clamp(1rem, 3vw, 2rem); display: grid; gap: 1.25rem; }
 .hero { display: flex; gap: 1rem; align-items: end; justify-content: space-between; }
 h1 { margin: 0; font-size: clamp(2rem, 5vw, 3.5rem); letter-spacing: -.045em; }
@@ -29,6 +30,9 @@ h2 { margin: 0; font-size: 1.15rem; }
 .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; padding: 1rem; border: 1px solid color-mix(in srgb, CanvasText 16%, transparent); border-radius: 18px; }
 .wide { grid-column: 1 / -1; }
 .prompt { display: grid; gap: .5rem; }
+.site-footer { margin-top: .75rem; padding-top: 1rem; border-top: 1px solid color-mix(in srgb, CanvasText 14%, transparent); font-size: .82rem; line-height: 1.5; opacity: .72; }
+.site-footer p { margin: 0; }
+.site-footer p + p { margin-top: .2rem; }
 @media (max-width: 700px) { .shell { padding: 1rem; } .hero { align-items: start; flex-direction: column; } #status { width: 100%; } .task-state dl { grid-template-columns: 1fr 1fr; } .grid { grid-template-columns: 1fr; } .wide { grid-column: auto; } .surfaces, .actions { grid-template-columns: 1fr 1fr; } }
 @media (max-width: 430px) { .task-state dl, .surfaces, .actions { grid-template-columns: 1fr; } button, input, select { min-height: 48px; } }
 @media (prefers-reduced-motion: reduce) { *, *::before, *::after { scroll-behavior: auto !important; transition: none !important; animation: none !important; } }

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -35,7 +35,7 @@
     <section class="grid" aria-label="Task setup">
       <label>Target repository <input id="repository" placeholder="owner/repo" autocomplete="off"></label>
       <label>Issue <input id="issue" inputmode="numeric" placeholder="optional"></label>
-      <label>Existing PR <input id="pull-request" inputmode="numeric" placeholder="blank for a new PR"></label>
+      <label>Existing PR <input id="pull-request" inputmode="numeric" placeholder="blank for new PR"></label>
       <label>Handoff mode
         <select id="handoff-mode"><option value="review">Review before handoff</option><option value="automatic">Automatic</option></select>
       </label>
@@ -92,6 +92,11 @@
     </section>
 
     <label class="prompt">Captured prompt <textarea id="prompt" rows="10" readonly></textarea></label>
+
+    <footer class="site-footer">
+      <p><a href="https://github.com/seedbed-ai/crossdock" target="_blank" rel="noopener noreferrer">Crossdock</a> is an open-source project by <a href="https://github.com/seedbed-ai" target="_blank" rel="noopener noreferrer">Seedbed</a>.</p>
+      <p>© 2026 Seedbed · <a href="https://github.com/seedbed-ai/crossdock/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">GNU AGPL v3</a></p>
+    </footer>
   </main>
   <script type="module" src="dashboard.js"></script>
   <script type="module" src="task-state-view.js"></script>


### PR DESCRIPTION
Adds subtle Seedbed branding to the Crossdock dashboard footer while preserving the existing “Developer handoff” eyebrow and Crossdock title.

The footer links Crossdock to the public repository, Seedbed to the GitHub organization, and GNU AGPL v3 to this repository's LICENSE file. Styling is intentionally subdued and inherits the existing responsive/color-scheme behavior.