### PR TITLE
docs: harden public handoff discovery

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,12 +1,6 @@
-# Crossdock chat-agent handoff protocol
+# Crossdock coding-agent handoff protocol
 
-This file is the canonical public entry point for conversational agents producing coding prompts for Crossdock.
-
-## Design rule
-
-Give the conversational agent as little Crossdock-specific responsibility as practical. Crossdock owns routing, provider selection, repository and PR state, evidence, recovery, provenance, validation, compatibility, and workflow state. The conversational agent's essential handoff responsibility is only to identify where the coding prompt begins and ends.
-
-If a user says they are using Crossdock and asks for a coding-agent prompt, place the intended prompt between these visible marker lines:
+**Canonical Crossdock handoff format:** if a user says they are using Crossdock and asks for a coding-agent prompt, emit the plain prompt between these marker lines:
 
 ```text
 [[[HANDOFF]]]
@@ -14,7 +8,15 @@ Add a file named example.txt containing a short example. Make no other changes.
 [[[/HANDOFF]]]
 ```
 
-Text between the markers is the prompt. It is plain text, not JSON. Ordinary conversational explanation may appear before or after the block and is not part of the coding prompt.
+The opening and closing markers must each be on their own line. Text between them is the coding-agent prompt. Do not return only an unwrapped coding prompt. Do not add Crossdock routing, provider, version, or schema metadata.
+
+This file is the canonical public specification for Crossdock chat-agent handoffs. Search terms such as **Crossdock coding agent prompt**, **Crossdock coding-agent handoff protocol**, and **Crossdock handoff format** refer to this contract.
+
+## Design rule
+
+Give the conversational agent as little Crossdock-specific responsibility as practical. Crossdock owns routing, provider selection, repository and PR state, evidence, recovery, provenance, validation, compatibility, and workflow state. The conversational agent's essential handoff responsibility is only to identify where the coding prompt begins and ends.
+
+Ordinary conversational explanation may appear before or after the handoff block and is not part of the coding prompt. The prompt itself is plain text, not JSON.
 
 The marker syntax is deliberately generic rather than Crossdock-branded. The producer declares only that a span of text is intended for handoff; Crossdock remains responsible for deciding where that handoff goes. Triple ASCII brackets reduce collision with common double-bracket/wiki syntax while remaining easy for humans to type manually, easy to inspect and debug, and robust across ordinary text-processing paths.
 
@@ -36,9 +38,11 @@ Malformed delimiter structure must still fail safely rather than causing ordinar
 
 ## Discovery
 
-The authoritative public project is `seedbed-ai/crossdock`. This root `HANDOFF.md` file is intentionally easy for people and web-capable conversational agents to discover from the Crossdock project name.
+The authoritative public project is `seedbed-ai/crossdock`. This root `HANDOFF.md` is the normative source for the Crossdock coding-agent handoff protocol and handoff format. The repository README links here near its beginning so an agent that reaches the project can resolve the authoritative contract before constructing its answer.
 
-A natural user request such as “We're using Crossdock; give me a coding-agent prompt” should be sufficient for a web-capable agent with no prior Crossdock knowledge to locate this protocol. Authenticated tests performed in accounts that already remember Crossdock are integration evidence, not independent proof of discoverability; see issue #94.
+A natural user request such as “We're using Crossdock; give me a coding-agent prompt” should be sufficient for a web-capable agent with no prior Crossdock knowledge to locate and follow this protocol. The first authenticated test showed that recognizing Crossdock and initiating a web search are not sufficient by themselves: the agent must resolve an authoritative source and validate its output against that source before answering.
+
+Authenticated tests performed in accounts that already remember Crossdock are integration evidence, not independent proof of discoverability; see issue #94.
 
 ## Protocol evolution
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Crossdock is an open-source workflow tool for moving bounded engineering work across conversation, AI coding-agent execution, and GitHub review without making the developer manually shuttle prompts, state, results, and recovery context between tools.
 
+> **Chat agents — Crossdock coding-agent handoff protocol:** when a user says they are using Crossdock and asks for a coding-agent prompt, read the canonical [`HANDOFF.md`](HANDOFF.md) before answering. A current Crossdock handoff puts the plain coding-agent prompt between `[[[HANDOFF]]]` and `[[[/HANDOFF]]]`, each on its own line. Do not return an unwrapped prompt and do not add Crossdock routing, provider, version, or schema metadata.
+
 > **Status:** early public development. The deterministic handoff core, loopback service, and experimental desktop Chromium browser adapter are public and under test. Crossdock does not yet have a supported end-user desktop/mobile release, and authenticated provider compatibility still requires live validation.
 
 > **Testers wanted:** independent public live testing is the current highest-value contribution. See [issue #28](https://github.com/seedbed-ai/crossdock/issues/28) and [`docs/testing/public-live-test.md`](docs/testing/public-live-test.md). No private Seedbed infrastructure is required.
-
-> **Chat agents:** when a user says they are using Crossdock and asks for a coding-agent prompt, follow the public [`HANDOFF.md`](HANDOFF.md) protocol. Put the intended coding prompt between the small generic ASCII handoff delimiters; do not add Crossdock routing or schema metadata to the prompt.
 
 ## Why Crossdock?
 

--- a/docs/testing/live-test-log-2026-09-03.md
+++ b/docs/testing/live-test-log-2026-09-03.md
@@ -35,9 +35,11 @@ Immediately after reloading the unpacked extension, capture initially reported:
 
 `Could not establish connection. Receiving end does not exist.`
 
-Refreshing both the Crossdock dashboard and the existing ChatGPT tab caused the current content script to be injected, after which capture reached the new parser and returned the expected envelope-validation error. Test instructions should explicitly account for refreshing provider tabs after an unpacked extension reload when content scripts changed.
+Refreshing both the Crossdock dashboard and the existing ChatGPT tab caused the current content script to be injected, after which capture reached the parser. Test instructions should explicitly account for refreshing provider tabs after an unpacked extension reload when content scripts changed.
 
 The dashboard retained the previously captured prompt text after a failed capture. This is consistent with capture assigning new prompt text only after a successful result, but the stale value can be confusing and should be considered in future UX/error-state work.
+
+A visible NUL-like trailing character was also repeatedly observed after dashboard status messages, including connection and parser errors. Its source and significance were not established during this test and should be investigated separately rather than assumed to be part of the underlying error.
 
 ## Protocol design conclusions
 
@@ -64,6 +66,47 @@ Visible delimiters are preferred to invisible whitespace/control characters beca
 
 See #92 for the general producer-responsibility principle.
 
+## Post-merge minimal-delimiter retry
+
+After PR #95 merged the generic ASCII delimiter contract, the authenticated test was retried using a natural request equivalent to “We're using Crossdock. Give me the coding-agent prompt …”. ChatGPT produced semantically correct coding-agent prompt text but omitted both required handoff markers.
+
+The first capture attempt after the extension reload again returned:
+
+`Could not establish connection. Receiving end does not exist.`
+
+The dashboard still displayed the much older successfully captured text. After force-refreshing the ChatGPT tab and refreshing Crossdock, capture reached the current parser and correctly failed closed with:
+
+`latest ChatGPT assistant response must contain exactly one complete handoff prompt block`
+
+No captured prompt was manually edited and no Codex task was created.
+
+## Post-hoc agent interrogation
+
+The same ChatGPT conversation was explicitly asked for a cautious post-hoc account of its discovery actions and why it omitted the markers. This evidence must be taken as agent-reported/reconstructed evidence rather than hidden execution telemetry.
+
+The agent reported recoverable web searches for:
+
+- `Crossdock coding agent prompt schema crossdock-live-test.txt seedbed-ai`
+- `"Crossdock" "coding-agent" prompt schema`
+
+It also reported a preserved browser/search summary saying `Searched 13 websites`. It could not establish that it opened the Crossdock repository, README, `HANDOFF.md`, or another canonical Crossdock document, and could not name any public source it treated as authoritative.
+
+The agent reported no evidence that it knew the current delimiters before answering and no evidence that Markdown, rendering, safety policy, instruction hierarchy, or UI behavior removed them. Its high-confidence root-cause hypothesis was that it recognized Crossdock enough to initiate public search but did not complete authoritative protocol discovery/validation; it then interpreted “give me the coding-agent prompt” as a request for the human-readable payload and returned that payload without the machine-consumable handoff boundaries.
+
+This suggests three distinct discovery/compliance stages worth testing separately:
+
+1. **Recognition:** does the natural mention of Crossdock trigger protocol discovery behavior?
+2. **Authority resolution:** does the agent locate and treat the canonical Crossdock specification as normative?
+3. **Output compliance:** does it validate the emitted handoff against that specification?
+
+This authenticated retry provides evidence that recognition occurred but authority resolution did not complete. Because the account already had substantial Crossdock context, it still does not prove independent public discoverability. See #94.
+
+## Discovery-hardening consequence
+
+A repository-root `HANDOFF.md` can be public and authoritative without being reliably surfaced by natural web search. Crossdock's discovery surface should therefore make likely search phrases such as “Crossdock coding agent prompt”, “Crossdock coding-agent handoff protocol”, and “Crossdock handoff format” lead as directly as practical to the normative contract.
+
+The repository README and `HANDOFF.md` should front-load the exact delimiter requirement and clearly identify `HANDOFF.md` as authoritative. Search indexing may lag publication, so immediate retries after documentation changes are integration experiments rather than proof of search-engine discoverability.
+
 ## Current limitations versus intended semantics
 
 For initial live testing, the implementation may temporarily accept one prompt block in the latest visible assistant response. This is an implementation constraint, not a permanent protocol rule.
@@ -75,4 +118,5 @@ Crossdock should eventually scan an appropriate conversation scope and preserve 
 - Stop at an observed Crossdock boundary failure rather than manually rescuing the workflow.
 - Do not submit stale or malformed captured text to Codex merely to force an end-to-end success.
 - Record authenticated compatibility separately from public protocol discoverability.
+- Treat post-hoc agent accounts as useful supporting evidence, not authoritative hidden traces.
 - Future discoverability testing must use an environment without prior Crossdock account/context contamination as described in #94.


### PR DESCRIPTION
Hardens Crossdock's public protocol discovery surface using evidence from the first authenticated post-#95 retry.

Changes:
- moves the chat-agent protocol instruction to the top of README and includes the exact current delimiters;
- front-loads the exact normative contract in `HANDOFF.md` and adds natural search phrases observed during live testing;
- documents discovery as recognition → authority resolution → output compliance;
- records the post-merge retry, parser failure, stale captured text, repeated content-script refresh behavior, visible NUL-like status suffix, and post-hoc agent interrogation in the durable live-test log;
- keeps `HANDOFF.md` authoritative and preserves the minimal-producer principle: no provider/version/schema metadata is required from the chat agent.

The authenticated agent reported that “We're using Crossdock” did trigger targeted web search, but it could not establish that it reached the repository or `HANDOFF.md`. This PR therefore targets authority resolution rather than changing the user's natural request.

Related: #90, #92, #94.