### PR TITLE
feat: select exact Codex repository before submission

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -27,7 +27,7 @@ function captureLatestAssistantResponse() {
 async function submitCodexPrompt(prompt, targetRepository) {
   requireCodexPage();
   if (typeof prompt !== "string" || !prompt.trim()) throw new Error("Codex prompt is empty");
-  assertCodexRepositoryContext(targetRepository);
+  await ensureCodexRepositoryContext(targetRepository);
 
   const input = findCodexPromptInput(true);
   setEditableValue(input, prompt);
@@ -39,41 +39,87 @@ async function submitCodexPrompt(prompt, targetRepository) {
   return { taskUrl };
 }
 
+async function ensureCodexRepositoryContext(targetRepository) {
+  if (typeof targetRepository !== "string" || !/^[^/\s]+\/[^/\s]+$/.test(targetRepository)) {
+    throw new Error("target repository must be owner/repo");
+  }
+
+  const selector = findUniqueSemanticButton("View all code environments");
+  if (visibleText(selector) === targetRepository) {
+    assertCodexRepositoryContext(targetRepository);
+    return;
+  }
+
+  selector.click();
+  const dialog = await waitForControlledDialog(selector, 5_000);
+  const candidates = [...dialog.querySelectorAll('button, [role="button"]')]
+    .filter(isVisible)
+    .filter(isEnabled)
+    .filter((node) => visibleText(node) === targetRepository);
+
+  if (candidates.length === 0) {
+    throw new Error(`Codex repository context is unresolved for target ${targetRepository}; repository is not visible in the environment chooser`);
+  }
+  if (candidates.length > 1) {
+    throw new Error(`Codex repository context is ambiguous for target ${targetRepository}; found ${candidates.length} exact repository choices`);
+  }
+
+  candidates[0].click();
+  await waitFor(() => visibleText(selector) === targetRepository && selector.getAttribute("aria-expanded") !== "true", 5_000,
+    `Codex repository selection was not confirmed for target ${targetRepository}`);
+  assertCodexRepositoryContext(targetRepository);
+}
+
 function assertCodexRepositoryContext(targetRepository) {
   if (typeof targetRepository !== "string" || !/^[^/\s]+\/[^/\s]+$/.test(targetRepository)) {
     throw new Error("target repository must be owner/repo");
   }
 
-  const expectedShort = targetRepository.split("/")[1];
-  const semanticSelectors = [
-    '[data-testid*="repository"]',
-    '[data-testid*="environment"]',
-    'button[aria-label*="repository" i]',
-    '[role="button"][aria-label*="repository" i]',
-    'button[aria-label*="environment" i]',
-    '[role="button"][aria-label*="environment" i]',
-  ];
-  const semantic = [...new Set(semanticSelectors.flatMap((selector) => [...document.querySelectorAll(selector)]))]
+  const environmentButton = findUniqueSemanticButton("View all code environments");
+  const selectedRepository = visibleText(environmentButton);
+  if (selectedRepository === targetRepository) return;
+
+  throw new Error(`Codex repository context does not match target ${targetRepository}; selected provider context: ${selectedRepository || "none"}`);
+}
+
+function findUniqueSemanticButton(ariaLabel) {
+  const buttons = [...document.querySelectorAll(`button[aria-label="${ariaLabel}"], [role="button"][aria-label="${ariaLabel}"]`)]
     .filter(isVisible)
-    .map((node) => accessibleText(node))
-    .filter(Boolean);
+    .filter(isEnabled);
+  if (buttons.length !== 1) throw new Error(`Codex semantic control must resolve to exactly one visible element for aria-label ${ariaLabel}; found ${buttons.length}`);
+  return buttons[0];
+}
 
-  const exactSemantic = semantic.filter((text) => text === targetRepository || text === expectedShort || text.endsWith(`/${expectedShort}`));
-  if (exactSemantic.length === 1) return;
-  if (exactSemantic.length > 1) throw new Error(`Codex repository context is ambiguous for target ${targetRepository}; found ${exactSemantic.length} matching semantic controls`);
+async function waitForControlledDialog(button, timeoutMs) {
+  return waitForResult(() => {
+    const controls = button.getAttribute("aria-controls");
+    if (controls) {
+      const controlled = document.getElementById(controls);
+      if (controlled && isVisible(controlled) && controlled.getAttribute("role") === "dialog") return controlled;
+    }
+    const dialogs = [...document.querySelectorAll('[role="dialog"]')].filter(isVisible);
+    if (dialogs.length === 1) return dialogs[0];
+    if (dialogs.length > 1) throw new Error(`Codex environment chooser is ambiguous; found ${dialogs.length} visible dialogs`);
+    return null;
+  }, timeoutMs, "Codex environment chooser did not open");
+}
 
-  const input = findCodexPromptInput(true);
-  const scope = input.closest("form") ?? input.parentElement?.parentElement?.parentElement ?? document;
-  const visibleLabels = [...new Set([...scope.querySelectorAll('button, [role="button"]')]
-    .filter(isVisible)
-    .map((node) => accessibleText(node))
-    .filter(Boolean))];
-  const exactLabels = visibleLabels.filter((text) => text === targetRepository || text === expectedShort || text.endsWith(`/${expectedShort}`));
-  if (exactLabels.length === 1) return;
-  if (exactLabels.length > 1) throw new Error(`Codex repository context is ambiguous for target ${targetRepository}; found ${exactLabels.length} matching composer controls`);
+async function waitFor(predicate, timeoutMs, message) {
+  await waitForResult(() => predicate() ? true : null, timeoutMs, message);
+}
 
-  const context = [...new Set([...semantic, ...visibleLabels])].slice(0, 12).join(", ") || "none";
-  throw new Error(`Codex repository context does not match target ${targetRepository}; visible provider context: ${context}`);
+async function waitForResult(producer, timeoutMs, message) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = producer();
+    if (result) return result;
+    await sleep(50);
+  }
+  throw new Error(message);
+}
+
+function visibleText(node) {
+  return normalizeText(node?.innerText || node?.textContent || "").replace(/\0/g, "");
 }
 
 async function waitForCodexSubmission({ beforeUrl, prompt }) {

--- a/tests/codex-repository-context-ui.test.js
+++ b/tests/codex-repository-context-ui.test.js
@@ -11,18 +11,25 @@ test("background passes configured target repository into Codex submission", () 
   assert.match(backgroundSource, /crossdock\.submitCodex[\s\S]*targetRepository/);
 });
 
-test("Codex submission validates repository context before writing or clicking", () => {
+test("Codex submission resolves repository context before writing or clicking", () => {
   const start = contentSource.indexOf("async function submitCodexPrompt");
-  const end = contentSource.indexOf("async function waitForCodexSubmission");
+  const end = contentSource.indexOf("async function ensureCodexRepositoryContext");
   const submit = contentSource.slice(start, end);
   assert.ok(start >= 0 && end > start);
-  assert.ok(submit.indexOf("assertCodexRepositoryContext(targetRepository)") < submit.indexOf("setEditableValue(input, prompt)"));
-  assert.ok(submit.indexOf("assertCodexRepositoryContext(targetRepository)") < submit.indexOf("findCodexSubmitButton(true).click()"));
+  assert.ok(submit.indexOf("await ensureCodexRepositoryContext(targetRepository)") < submit.indexOf("setEditableValue(input, prompt)"));
+  assert.ok(submit.indexOf("await ensureCodexRepositoryContext(targetRepository)") < submit.indexOf("findCodexSubmitButton(true).click()"));
 });
 
-test("repository context mismatch and ambiguity fail closed", () => {
-  assert.match(contentSource, /Codex repository context does not match target/);
-  assert.match(contentSource, /Codex repository context is ambiguous/);
-  assert.match(contentSource, /data-testid\*=\\?"repository\\?"/);
-  assert.match(contentSource, /aria-label\*=\\?"repository\\?" i/);
+test("repository selection uses authenticated Codex semantic controls and exact repository text", () => {
+  assert.match(contentSource, /View all code environments/);
+  assert.match(contentSource, /waitForControlledDialog/);
+  assert.match(contentSource, /visibleText\(node\) === targetRepository/);
+  assert.match(contentSource, /repository is not visible in the environment chooser/);
+  assert.match(contentSource, /found \$\{candidates\.length\} exact repository choices/);
+});
+
+test("repository selection is confirmed before the old fail-closed assertion returns", () => {
+  assert.match(contentSource, /visibleText\(selector\) === targetRepository/);
+  assert.match(contentSource, /Codex repository selection was not confirmed/);
+  assert.match(contentSource, /selected provider context/);
 });


### PR DESCRIPTION
Implements the next provider-context routing slice from #108 using authenticated Codex DOM evidence.

- Resolves the semantic `View all code environments` control.
- If the configured target repository is not already selected, opens the chooser and selects the exact `owner/repo` repository entry.
- Fails closed when the repository entry is missing or ambiguous.
- Waits for the selected provider context to visibly confirm the exact target repository before touching the prompt.
- Preserves the existing invariant that prompt write and Submit happen only after provider context resolution.
- Adds source-level regression coverage for the authenticated semantic anchors and ordering.

This PR intentionally does not yet freeze/select the target base branch from `/repository/snapshot`; that is the next slice before another full E2E run.