### PR TITLE
feat: select and verify Codex base branch

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,5 +1,6 @@
 import { extractCrossdockHandoff } from "./chat-agent-handoff.js";
 import { canonicalGitHubPrUrl, classifyNewPrUrls, repositoryFromGitHubPrUrl } from "./pr-discovery.js";
+import { postServiceJson } from "./service-client.js";
 
 const CHATGPT_URL = "https://chatgpt.com/";
 const CODEX_URL = "https://chatgpt.com/codex/cloud";
@@ -28,10 +29,25 @@ async function handleMessage(message) {
       if (typeof targetRepository !== "string" || !/^[^/\s]+\/[^/\s]+$/.test(targetRepository)) {
         throw new Error("target repository must be configured as owner/repo before Codex submission");
       }
+      const serviceUrl = stored.dashboard?.["service-url"];
+      const snapshot = await postServiceJson({
+        path: "/repository/snapshot",
+        body: { target_repository: targetRepository },
+        preference: serviceUrl,
+      });
+      if (snapshot.repository !== targetRepository || typeof snapshot.default_branch !== "string" || !snapshot.default_branch.trim()) {
+        throw new Error("target repository snapshot did not return the configured repository and default branch");
+      }
+      const targetBranch = snapshot.default_branch.trim();
       const tab = await ensureCodexTab();
-      const result = await sendToTab(tab.id, { type: "crossdock.submitCodex", prompt: message.prompt, targetRepository });
+      const result = await sendToTab(tab.id, {
+        type: "crossdock.submitCodex",
+        prompt: message.prompt,
+        targetRepository,
+        targetBranch,
+      });
       await chrome.tabs.update(tab.id, { active: true });
-      return result;
+      return { ...result, providerContext: { repository: targetRepository, base_branch: targetBranch } };
     }
     case "crossdock.inspectCodex": {
       const tab = await findChatGptTab(true);

--- a/extension/content.js
+++ b/extension/content.js
@@ -170,6 +170,9 @@ async function waitForCodexSubmission({ beforeUrl, prompt }) {
     const composerNoLongerContainsPrompt = !currentInput || currentValue !== prompt;
     const submitStillAvailable = Boolean(findCodexSubmitButton(false));
 
+    // Codex may transition in place before assigning a task URL. Require both
+    // the submitted prompt to leave the composer and the submit/start control
+    // to disappear before claiming that submission succeeded.
     if (composerNoLongerContainsPrompt && !submitStillAvailable) return location.href;
 
     await sleep(100);
@@ -207,7 +210,7 @@ function findCodexSubmitButton(required = true) {
     .filter(isEnabled)
     .filter((node) => normalizedLabels.has(accessibleText(node).toLowerCase()));
 
-  if (buttons.length > 1) throw new Error(`Codex submit control is ambiguous; found ${buttons.length} semantic candidates`);
+  if (buttons.length > 1) throw new Error(`Codex submit control is ambiguous; found ${buttons.length} label candidates`);
   if (required && buttons.length !== 1) throw new Error(`required Codex submit control not found; expected one of: ${labels.join(", ")}`);
   return buttons[0] ?? null;
 }
@@ -282,6 +285,10 @@ function sliceCodexReportText(text) {
   const testingIndex = lines.findIndex((line, index) => index > summaryIndex && line === "Testing");
   if (testingIndex < 0) return null;
 
+  // The current Codex task UI renders the completion report as a structured
+  // Summary/Testing block without the old report-specific data-testid. Anchor
+  // on those visible semantic headings and take the smallest ancestor that
+  // contains both, then discard any prompt/task chrome that precedes Summary.
   const reportLines = lines.slice(summaryIndex);
   if (reportLines.length < 4) return null;
   return reportLines.join("\n");

--- a/extension/content.js
+++ b/extension/content.js
@@ -8,7 +8,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 async function handleMessage(message) {
   switch (message.type) {
     case "crossdock.capturePrompt": return { assistantResponse: captureLatestAssistantResponse(), url: location.href };
-    case "crossdock.submitCodex": return submitCodexPrompt(message.prompt, message.targetRepository);
+    case "crossdock.submitCodex": return submitCodexPrompt(message.prompt, message.targetRepository, message.targetBranch);
     case "crossdock.inspectCodex": return inspectCodexTask();
     case "crossdock.findPrUrls": return { prUrls: findPullRequestLinks(message.targetRepository) };
     case "crossdock.prepareCreatePr": return prepareCreatePr(message.captureReport !== false);
@@ -24,10 +24,11 @@ function captureLatestAssistantResponse() {
   return nodes.at(-1);
 }
 
-async function submitCodexPrompt(prompt, targetRepository) {
+async function submitCodexPrompt(prompt, targetRepository, targetBranch) {
   requireCodexPage();
   if (typeof prompt !== "string" || !prompt.trim()) throw new Error("Codex prompt is empty");
   await ensureCodexRepositoryContext(targetRepository);
+  await ensureCodexBranchContext(targetBranch);
 
   const input = findCodexPromptInput(true);
   setEditableValue(input, prompt);
@@ -36,7 +37,7 @@ async function submitCodexPrompt(prompt, targetRepository) {
   findCodexSubmitButton(true).click();
 
   const taskUrl = await waitForCodexSubmission({ beforeUrl, prompt });
-  return { taskUrl };
+  return { taskUrl, providerContext: { repository: targetRepository, base_branch: targetBranch } };
 }
 
 async function ensureCodexRepositoryContext(targetRepository) {
@@ -51,11 +52,8 @@ async function ensureCodexRepositoryContext(targetRepository) {
   }
 
   selector.click();
-  const dialog = await waitForControlledDialog(selector, 5_000);
-  const candidates = [...dialog.querySelectorAll('button, [role="button"]')]
-    .filter(isVisible)
-    .filter(isEnabled)
-    .filter((node) => visibleText(node) === targetRepository);
+  const dialog = await waitForControlledDialog(selector, 5_000, "Codex environment chooser did not open");
+  const candidates = exactVisibleButtonChoices(dialog, targetRepository);
 
   if (candidates.length === 0) {
     throw new Error(`Codex repository context is unresolved for target ${targetRepository}; repository is not visible in the environment chooser`);
@@ -70,6 +68,32 @@ async function ensureCodexRepositoryContext(targetRepository) {
   assertCodexRepositoryContext(targetRepository);
 }
 
+async function ensureCodexBranchContext(targetBranch) {
+  if (typeof targetBranch !== "string" || !targetBranch.trim()) throw new Error("target branch is required before Codex submission");
+  const expected = targetBranch.trim();
+  const selector = findUniqueSemanticButton("Search for your branch");
+  if (visibleText(selector) === expected) {
+    assertCodexBranchContext(expected);
+    return;
+  }
+
+  selector.click();
+  const dialog = await waitForControlledDialog(selector, 5_000, "Codex branch chooser did not open");
+  const candidates = exactVisibleButtonChoices(dialog, expected);
+
+  if (candidates.length === 0) {
+    throw new Error(`Codex branch context is unresolved for target ${expected}; branch is not visible in the branch chooser`);
+  }
+  if (candidates.length > 1) {
+    throw new Error(`Codex branch context is ambiguous for target ${expected}; found ${candidates.length} exact branch choices`);
+  }
+
+  candidates[0].click();
+  await waitFor(() => visibleText(selector) === expected && selector.getAttribute("aria-expanded") !== "true", 5_000,
+    `Codex branch selection was not confirmed for target ${expected}`);
+  assertCodexBranchContext(expected);
+}
+
 function assertCodexRepositoryContext(targetRepository) {
   if (typeof targetRepository !== "string" || !/^[^/\s]+\/[^/\s]+$/.test(targetRepository)) {
     throw new Error("target repository must be owner/repo");
@@ -82,6 +106,20 @@ function assertCodexRepositoryContext(targetRepository) {
   throw new Error(`Codex repository context does not match target ${targetRepository}; selected provider context: ${selectedRepository || "none"}`);
 }
 
+function assertCodexBranchContext(targetBranch) {
+  const branchButton = findUniqueSemanticButton("Search for your branch");
+  const selectedBranch = visibleText(branchButton);
+  if (selectedBranch === targetBranch) return;
+  throw new Error(`Codex branch context does not match target ${targetBranch}; selected provider branch: ${selectedBranch || "none"}`);
+}
+
+function exactVisibleButtonChoices(scope, expectedText) {
+  return [...scope.querySelectorAll('button, [role="button"]')]
+    .filter(isVisible)
+    .filter(isEnabled)
+    .filter((node) => visibleText(node) === expectedText);
+}
+
 function findUniqueSemanticButton(ariaLabel) {
   const buttons = [...document.querySelectorAll(`button[aria-label="${ariaLabel}"], [role="button"][aria-label="${ariaLabel}"]`)]
     .filter(isVisible)
@@ -90,7 +128,7 @@ function findUniqueSemanticButton(ariaLabel) {
   return buttons[0];
 }
 
-async function waitForControlledDialog(button, timeoutMs) {
+async function waitForControlledDialog(button, timeoutMs, message) {
   return waitForResult(() => {
     const controls = button.getAttribute("aria-controls");
     if (controls) {
@@ -99,9 +137,9 @@ async function waitForControlledDialog(button, timeoutMs) {
     }
     const dialogs = [...document.querySelectorAll('[role="dialog"]')].filter(isVisible);
     if (dialogs.length === 1) return dialogs[0];
-    if (dialogs.length > 1) throw new Error(`Codex environment chooser is ambiguous; found ${dialogs.length} visible dialogs`);
+    if (dialogs.length > 1) throw new Error(`Codex chooser is ambiguous; found ${dialogs.length} visible dialogs`);
     return null;
-  }, timeoutMs, "Codex environment chooser did not open");
+  }, timeoutMs, message);
 }
 
 async function waitFor(predicate, timeoutMs, message) {
@@ -132,9 +170,6 @@ async function waitForCodexSubmission({ beforeUrl, prompt }) {
     const composerNoLongerContainsPrompt = !currentInput || currentValue !== prompt;
     const submitStillAvailable = Boolean(findCodexSubmitButton(false));
 
-    // Codex may transition in place before assigning a task URL. Require both
-    // the submitted prompt to leave the composer and the submit/start control
-    // to disappear before claiming that submission succeeded.
     if (composerNoLongerContainsPrompt && !submitStillAvailable) return location.href;
 
     await sleep(100);
@@ -172,7 +207,7 @@ function findCodexSubmitButton(required = true) {
     .filter(isEnabled)
     .filter((node) => normalizedLabels.has(accessibleText(node).toLowerCase()));
 
-  if (buttons.length > 1) throw new Error(`Codex submit control is ambiguous; found ${buttons.length} label candidates`);
+  if (buttons.length > 1) throw new Error(`Codex submit control is ambiguous; found ${buttons.length} semantic candidates`);
   if (required && buttons.length !== 1) throw new Error(`required Codex submit control not found; expected one of: ${labels.join(", ")}`);
   return buttons[0] ?? null;
 }
@@ -247,10 +282,6 @@ function sliceCodexReportText(text) {
   const testingIndex = lines.findIndex((line, index) => index > summaryIndex && line === "Testing");
   if (testingIndex < 0) return null;
 
-  // The current Codex task UI renders the completion report as a structured
-  // Summary/Testing block without the old report-specific data-testid. Anchor
-  // on those visible semantic headings and take the smallest ancestor that
-  // contains both, then discard any prompt/task chrome that precedes Summary.
   const reportLines = lines.slice(summaryIndex);
   if (reportLines.length < 4) return null;
   return reportLines.join("\n");

--- a/tests/codex-repository-context-ui.test.js
+++ b/tests/codex-repository-context-ui.test.js
@@ -5,31 +5,47 @@ import { readFile } from "node:fs/promises";
 const contentSource = await readFile(new URL("../extension/content.js", import.meta.url), "utf8");
 const backgroundSource = await readFile(new URL("../extension/background.js", import.meta.url), "utf8");
 
-test("background passes configured target repository into Codex submission", () => {
-  assert.match(backgroundSource, /chrome\.storage\.local\.get\("dashboard"\)/);
+test("background snapshots repository default branch and passes frozen provider target into Codex submission", () => {
+  assert.match(backgroundSource, /postServiceJson/);
+  assert.match(backgroundSource, /path: "\/repository\/snapshot"/);
+  assert.match(backgroundSource, /snapshot\.default_branch/);
   assert.match(backgroundSource, /targetRepository/);
-  assert.match(backgroundSource, /crossdock\.submitCodex[\s\S]*targetRepository/);
+  assert.match(backgroundSource, /targetBranch/);
+  assert.match(backgroundSource, /crossdock\.submitCodex[\s\S]*targetRepository[\s\S]*targetBranch/);
 });
 
-test("Codex submission resolves repository context before writing or clicking", () => {
+test("Codex submission resolves repository and branch context before writing or clicking", () => {
   const start = contentSource.indexOf("async function submitCodexPrompt");
   const end = contentSource.indexOf("async function ensureCodexRepositoryContext");
   const submit = contentSource.slice(start, end);
   assert.ok(start >= 0 && end > start);
-  assert.ok(submit.indexOf("await ensureCodexRepositoryContext(targetRepository)") < submit.indexOf("setEditableValue(input, prompt)"));
-  assert.ok(submit.indexOf("await ensureCodexRepositoryContext(targetRepository)") < submit.indexOf("findCodexSubmitButton(true).click()"));
+  const repositoryResolution = submit.indexOf("await ensureCodexRepositoryContext(targetRepository)");
+  const branchResolution = submit.indexOf("await ensureCodexBranchContext(targetBranch)");
+  const promptWrite = submit.indexOf("setEditableValue(input, prompt)");
+  const submitClick = submit.indexOf("findCodexSubmitButton(true).click()");
+  assert.ok(repositoryResolution >= 0 && repositoryResolution < branchResolution);
+  assert.ok(branchResolution < promptWrite);
+  assert.ok(branchResolution < submitClick);
 });
 
 test("repository selection uses authenticated Codex semantic controls and exact repository text", () => {
   assert.match(contentSource, /View all code environments/);
   assert.match(contentSource, /waitForControlledDialog/);
-  assert.match(contentSource, /visibleText\(node\) === targetRepository/);
+  assert.match(contentSource, /exactVisibleButtonChoices\(dialog, targetRepository\)/);
   assert.match(contentSource, /repository is not visible in the environment chooser/);
-  assert.match(contentSource, /found \$\{candidates\.length\} exact repository choices/);
+  assert.match(contentSource, /exact repository choices/);
 });
 
-test("repository selection is confirmed before the old fail-closed assertion returns", () => {
-  assert.match(contentSource, /visibleText\(selector\) === targetRepository/);
-  assert.match(contentSource, /Codex repository selection was not confirmed/);
-  assert.match(contentSource, /selected provider context/);
+test("branch selection uses authenticated Codex semantic controls and exact branch text", () => {
+  assert.match(contentSource, /Search for your branch/);
+  assert.match(contentSource, /ensureCodexBranchContext/);
+  assert.match(contentSource, /exactVisibleButtonChoices\(dialog, expected\)/);
+  assert.match(contentSource, /branch is not visible in the branch chooser/);
+  assert.match(contentSource, /Codex branch selection was not confirmed/);
+  assert.match(contentSource, /selected provider branch/);
+});
+
+test("provider context is returned with exact repository and frozen base branch", () => {
+  assert.match(contentSource, /providerContext: \{ repository: targetRepository, base_branch: targetBranch \}/);
+  assert.match(backgroundSource, /providerContext: \{ repository: targetRepository, base_branch: targetBranch \}/);
 });


### PR DESCRIPTION
Continues #108 by freezing the initial task base branch from GitHub before provider mutation and verifying that exact branch in Codex.

- Reads `/repository/snapshot` through the configured loopback Crossdock service before opening/submitting Codex work.
- Requires the snapshot to match the configured repository and return a non-empty default branch.
- Passes the exact repository + base branch to the content adapter.
- Selects the exact repository first, then the exact branch through authenticated semantic controls.
- Fails closed if either chooser is unresolved or ambiguous.
- Preserves the invariant that no prompt text is written and Submit is not clicked until both repository and branch are visibly confirmed.
- Returns the resolved provider context with the submission result for later persistence/reverification work.

This is still pre-task routing only. Post-submit task-context capture and pre-PR revalidation remain separate follow-up work.