### PR TITLE
fix: confirm Codex context from live selectors

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -63,8 +63,10 @@ async function ensureCodexRepositoryContext(targetRepository) {
   }
 
   candidates[0].click();
-  await waitFor(() => visibleText(selector) === targetRepository && selector.getAttribute("aria-expanded") !== "true", 5_000,
-    `Codex repository selection was not confirmed for target ${targetRepository}`);
+  await waitFor(() => {
+    const currentSelector = findUniqueSemanticButton("View all code environments");
+    return visibleText(currentSelector) === targetRepository && currentSelector.getAttribute("aria-expanded") !== "true";
+  }, 5_000, `Codex repository selection was not confirmed for target ${targetRepository}`);
   assertCodexRepositoryContext(targetRepository);
 }
 
@@ -89,8 +91,10 @@ async function ensureCodexBranchContext(targetBranch) {
   }
 
   candidates[0].click();
-  await waitFor(() => visibleText(selector) === expected && selector.getAttribute("aria-expanded") !== "true", 5_000,
-    `Codex branch selection was not confirmed for target ${expected}`);
+  await waitFor(() => {
+    const currentSelector = findUniqueSemanticButton("Search for your branch");
+    return visibleText(currentSelector) === expected && currentSelector.getAttribute("aria-expanded") !== "true";
+  }, 5_000, `Codex branch selection was not confirmed for target ${expected}`);
   assertCodexBranchContext(expected);
 }
 

--- a/tests/codex-repository-context-ui.test.js
+++ b/tests/codex-repository-context-ui.test.js
@@ -36,6 +36,17 @@ test("repository selection uses authenticated Codex semantic controls and exact 
   assert.match(contentSource, /exact repository choices/);
 });
 
+test("repository confirmation re-resolves the live semantic selector after selection", () => {
+  const start = contentSource.indexOf("async function ensureCodexRepositoryContext");
+  const end = contentSource.indexOf("async function ensureCodexBranchContext");
+  const repositorySelection = contentSource.slice(start, end);
+  assert.ok(start >= 0 && end > start);
+  assert.match(repositorySelection, /candidates\[0\]\.click\(\);[\s\S]*await waitFor\(\(\) => \{[\s\S]*const currentSelector = findUniqueSemanticButton\("View all code environments"\)/);
+  assert.match(repositorySelection, /visibleText\(currentSelector\) === targetRepository/);
+  assert.match(repositorySelection, /currentSelector\.getAttribute\("aria-expanded"\) !== "true"/);
+  assert.doesNotMatch(repositorySelection, /await waitFor\(\(\) => visibleText\(selector\) === targetRepository/);
+});
+
 test("branch selection uses authenticated Codex semantic controls and exact branch text", () => {
   assert.match(contentSource, /Search for your branch/);
   assert.match(contentSource, /ensureCodexBranchContext/);
@@ -43,6 +54,17 @@ test("branch selection uses authenticated Codex semantic controls and exact bran
   assert.match(contentSource, /branch is not visible in the branch chooser/);
   assert.match(contentSource, /Codex branch selection was not confirmed/);
   assert.match(contentSource, /selected provider branch/);
+});
+
+test("branch confirmation re-resolves the live semantic selector after selection", () => {
+  const start = contentSource.indexOf("async function ensureCodexBranchContext");
+  const end = contentSource.indexOf("function assertCodexRepositoryContext");
+  const branchSelection = contentSource.slice(start, end);
+  assert.ok(start >= 0 && end > start);
+  assert.match(branchSelection, /candidates\[0\]\.click\(\);[\s\S]*await waitFor\(\(\) => \{[\s\S]*const currentSelector = findUniqueSemanticButton\("Search for your branch"\)/);
+  assert.match(branchSelection, /visibleText\(currentSelector\) === expected/);
+  assert.match(branchSelection, /currentSelector\.getAttribute\("aria-expanded"\) !== "true"/);
+  assert.doesNotMatch(branchSelection, /await waitFor\(\(\) => visibleText\(selector\) === expected/);
 });
 
 test("provider context is returned with exact repository and frozen base branch", () => {


### PR DESCRIPTION
Fixes #125.

Authenticated Codex testing showed repository selection succeeded visually but Crossdock timed out because the post-click confirmation continued polling a pre-selection DOM node that React replaced during rerender.

This change re-resolves the unique live semantic repository selector on every confirmation poll and applies the same defensive pattern to branch confirmation. Exact repository/branch equality, fail-closed behavior, semantic selectors, and no coordinate/order guessing are preserved.

Regression coverage verifies both repository and branch confirmation no longer poll the pre-click selector reference.