### PR TITLE
fix: allow slow Codex context transitions to settle

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -5,6 +5,8 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   return true;
 });
 
+const CODEX_CONTEXT_SELECTION_TIMEOUT_MS = 20_000;
+
 async function handleMessage(message) {
   switch (message.type) {
     case "crossdock.capturePrompt": return { assistantResponse: captureLatestAssistantResponse(), url: location.href };
@@ -66,7 +68,7 @@ async function ensureCodexRepositoryContext(targetRepository) {
   await waitFor(() => {
     const currentSelector = findUniqueSemanticButton("View all code environments");
     return visibleText(currentSelector) === targetRepository && currentSelector.getAttribute("aria-expanded") !== "true";
-  }, 5_000, `Codex repository selection was not confirmed for target ${targetRepository}`);
+  }, CODEX_CONTEXT_SELECTION_TIMEOUT_MS, `Codex repository selection was not confirmed for target ${targetRepository}`);
   assertCodexRepositoryContext(targetRepository);
 }
 
@@ -94,7 +96,7 @@ async function ensureCodexBranchContext(targetBranch) {
   await waitFor(() => {
     const currentSelector = findUniqueSemanticButton("Search for your branch");
     return visibleText(currentSelector) === expected && currentSelector.getAttribute("aria-expanded") !== "true";
-  }, 5_000, `Codex branch selection was not confirmed for target ${expected}`);
+  }, CODEX_CONTEXT_SELECTION_TIMEOUT_MS, `Codex branch selection was not confirmed for target ${expected}`);
   assertCodexBranchContext(expected);
 }
 
@@ -214,7 +216,7 @@ function findCodexSubmitButton(required = true) {
     .filter(isEnabled)
     .filter((node) => normalizedLabels.has(accessibleText(node).toLowerCase()));
 
-  if (buttons.length > 1) throw new Error(`Codex submit control is ambiguous; found ${buttons.length} label candidates`);
+  if (buttons.length > 1) throw new Error(`Codex submit control is ambiguous; found ${buttons.length} semantic candidates`);
   if (required && buttons.length !== 1) throw new Error(`required Codex submit control not found; expected one of: ${labels.join(", ")}`);
   return buttons[0] ?? null;
 }

--- a/extension/content.js
+++ b/extension/content.js
@@ -216,7 +216,7 @@ function findCodexSubmitButton(required = true) {
     .filter(isEnabled)
     .filter((node) => normalizedLabels.has(accessibleText(node).toLowerCase()));
 
-  if (buttons.length > 1) throw new Error(`Codex submit control is ambiguous; found ${buttons.length} semantic candidates`);
+  if (buttons.length > 1) throw new Error(`Codex submit control is ambiguous; found ${buttons.length} label candidates`);
   if (required && buttons.length !== 1) throw new Error(`required Codex submit control not found; expected one of: ${labels.join(", ")}`);
   return buttons[0] ?? null;
 }

--- a/tests/codex-repository-context-ui.test.js
+++ b/tests/codex-repository-context-ui.test.js
@@ -47,6 +47,15 @@ test("repository confirmation re-resolves the live semantic selector after selec
   assert.doesNotMatch(repositorySelection, /await waitFor\(\(\) => visibleText\(selector\) === targetRepository/);
 });
 
+test("repository confirmation allows authenticated slow provider transitions to settle", () => {
+  const start = contentSource.indexOf("async function ensureCodexRepositoryContext");
+  const end = contentSource.indexOf("async function ensureCodexBranchContext");
+  const repositorySelection = contentSource.slice(start, end);
+  assert.match(contentSource, /const CODEX_CONTEXT_SELECTION_TIMEOUT_MS = 20_000;/);
+  assert.match(repositorySelection, /CODEX_CONTEXT_SELECTION_TIMEOUT_MS/);
+  assert.doesNotMatch(repositorySelection, /\}, 5_000, `Codex repository selection was not confirmed/);
+});
+
 test("branch selection uses authenticated Codex semantic controls and exact branch text", () => {
   assert.match(contentSource, /Search for your branch/);
   assert.match(contentSource, /ensureCodexBranchContext/);
@@ -65,6 +74,14 @@ test("branch confirmation re-resolves the live semantic selector after selection
   assert.match(branchSelection, /visibleText\(currentSelector\) === expected/);
   assert.match(branchSelection, /currentSelector\.getAttribute\("aria-expanded"\) !== "true"/);
   assert.doesNotMatch(branchSelection, /await waitFor\(\(\) => visibleText\(selector\) === expected/);
+});
+
+test("branch confirmation uses the same slow-transition timeout", () => {
+  const start = contentSource.indexOf("async function ensureCodexBranchContext");
+  const end = contentSource.indexOf("function assertCodexRepositoryContext");
+  const branchSelection = contentSource.slice(start, end);
+  assert.match(branchSelection, /CODEX_CONTEXT_SELECTION_TIMEOUT_MS/);
+  assert.doesNotMatch(branchSelection, /\}, 5_000, `Codex branch selection was not confirmed/);
 });
 
 test("provider context is returned with exact repository and frozen base branch", () => {


### PR DESCRIPTION
Fixes #125.

Authenticated timing evidence showed Codex repository selection can remain open for roughly 11 seconds before the semantic selector settles to the exact target repository and branch. The previous 5-second post-selection confirmation timeout therefore failed closed even though the provider completed the requested transition shortly afterward.

This change preserves live semantic re-resolution, exact repository/branch equality, and fail-closed behavior, while using a 20-second context-selection confirmation window for repository and branch transitions. The chooser-open timeout remains 5 seconds.

Regression coverage verifies both confirmation paths use the extended context-transition timeout and no longer use the 5-second selection timeout.