### PR TITLE
fix: extend Codex context confirmation timeout

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -5,7 +5,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   return true;
 });
 
-const CODEX_CONTEXT_SELECTION_TIMEOUT_MS = 20_000;
+const CODEX_CONTEXT_SELECTION_TIMEOUT_MS = 45_000;
 
 async function handleMessage(message) {
   switch (message.type) {

--- a/tests/codex-repository-context-ui.test.js
+++ b/tests/codex-repository-context-ui.test.js
@@ -47,12 +47,13 @@ test("repository confirmation re-resolves the live semantic selector after selec
   assert.doesNotMatch(repositorySelection, /await waitFor\(\(\) => visibleText\(selector\) === targetRepository/);
 });
 
-test("repository confirmation allows authenticated slow provider transitions to settle", () => {
+test("repository confirmation allows observed slow provider transitions to settle with margin", () => {
   const start = contentSource.indexOf("async function ensureCodexRepositoryContext");
   const end = contentSource.indexOf("async function ensureCodexBranchContext");
   const repositorySelection = contentSource.slice(start, end);
-  assert.match(contentSource, /const CODEX_CONTEXT_SELECTION_TIMEOUT_MS = 20_000;/);
+  assert.match(contentSource, /const CODEX_CONTEXT_SELECTION_TIMEOUT_MS = 45_000;/);
   assert.match(repositorySelection, /CODEX_CONTEXT_SELECTION_TIMEOUT_MS/);
+  assert.doesNotMatch(repositorySelection, /\}, 20_000, `Codex repository selection was not confirmed/);
   assert.doesNotMatch(repositorySelection, /\}, 5_000, `Codex repository selection was not confirmed/);
 });
 
@@ -76,11 +77,12 @@ test("branch confirmation re-resolves the live semantic selector after selection
   assert.doesNotMatch(branchSelection, /await waitFor\(\(\) => visibleText\(selector\) === expected/);
 });
 
-test("branch confirmation uses the same slow-transition timeout", () => {
+test("branch confirmation uses the same extended transition timeout", () => {
   const start = contentSource.indexOf("async function ensureCodexBranchContext");
   const end = contentSource.indexOf("function assertCodexRepositoryContext");
   const branchSelection = contentSource.slice(start, end);
   assert.match(branchSelection, /CODEX_CONTEXT_SELECTION_TIMEOUT_MS/);
+  assert.doesNotMatch(branchSelection, /\}, 20_000, `Codex branch selection was not confirmed/);
   assert.doesNotMatch(branchSelection, /\}, 5_000, `Codex branch selection was not confirmed/);
 });
 


### PR DESCRIPTION
Fixes #125.

Fresh authenticated testing on 2026-09-05 after a full EC2 reboot and new browser sessions showed the Codex repository transition taking about 27.6 seconds after the repository selector opened before the exact target repository and branch appeared. The existing 20-second confirmation window therefore failed closed before Codex completed the transition.

This change increases the bounded repository/branch context-confirmation window to 45 seconds while preserving the 5-second chooser-open timeout, exact semantic repository/branch matching, live selector re-resolution, and fail-closed behavior. Prompt mutation and submission still occur only after both contexts are confirmed.

Regression coverage verifies both repository and branch confirmation use the 45-second context transition budget and no longer rely on the previous 20-second or 5-second post-selection windows.