### PR TITLE
fix: allow long Codex context transitions

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -5,7 +5,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   return true;
 });
 
-const CODEX_CONTEXT_SELECTION_TIMEOUT_MS = 45_000;
+const CODEX_CONTEXT_SELECTION_TIMEOUT_MS = 120_000;
 
 async function handleMessage(message) {
   switch (message.type) {

--- a/tests/codex-repository-context-ui.test.js
+++ b/tests/codex-repository-context-ui.test.js
@@ -51,8 +51,9 @@ test("repository confirmation allows observed slow provider transitions to settl
   const start = contentSource.indexOf("async function ensureCodexRepositoryContext");
   const end = contentSource.indexOf("async function ensureCodexBranchContext");
   const repositorySelection = contentSource.slice(start, end);
-  assert.match(contentSource, /const CODEX_CONTEXT_SELECTION_TIMEOUT_MS = 45_000;/);
+  assert.match(contentSource, /const CODEX_CONTEXT_SELECTION_TIMEOUT_MS = 120_000;/);
   assert.match(repositorySelection, /CODEX_CONTEXT_SELECTION_TIMEOUT_MS/);
+  assert.doesNotMatch(repositorySelection, /\}, 45_000, `Codex repository selection was not confirmed/);
   assert.doesNotMatch(repositorySelection, /\}, 20_000, `Codex repository selection was not confirmed/);
   assert.doesNotMatch(repositorySelection, /\}, 5_000, `Codex repository selection was not confirmed/);
 });
@@ -82,6 +83,7 @@ test("branch confirmation uses the same extended transition timeout", () => {
   const end = contentSource.indexOf("function assertCodexRepositoryContext");
   const branchSelection = contentSource.slice(start, end);
   assert.match(branchSelection, /CODEX_CONTEXT_SELECTION_TIMEOUT_MS/);
+  assert.doesNotMatch(branchSelection, /\}, 45_000, `Codex branch selection was not confirmed/);
   assert.doesNotMatch(branchSelection, /\}, 20_000, `Codex branch selection was not confirmed/);
   assert.doesNotMatch(branchSelection, /\}, 5_000, `Codex branch selection was not confirmed/);
 });


### PR DESCRIPTION
Fixes #131.

Authenticated live testing on 2026-09-05 observed Codex taking about 65.3 seconds from repository chooser-open to the exact target repository/branch settling. The current 45-second bounded confirmation window therefore fails closed before Codex finishes.

This change increases only the repository/branch context-confirmation budget to 120 seconds. It preserves the 5-second chooser-open timeout, exact semantic repository/branch equality, live selector re-resolution, fail-closed behavior, and prompt/submission ordering. It deliberately does not depend on tooltip text: the semantic selector's DOM text already provides the full repository identity even when visually truncated, while tooltip presence is transient and was absent during the measured transitions.

Regression coverage verifies repository and branch confirmation use the new bounded budget and no longer rely on the prior 45/20/5-second post-selection windows.