### PR TITLE
fix: foreground Codex before provider automation

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -40,13 +40,16 @@ async function handleMessage(message) {
       }
       const targetBranch = snapshot.default_branch.trim();
       const tab = await ensureCodexTab();
+      // Codex repository/environment transitions are provider UI work. Keep the
+      // provider tab foregrounded before driving those controls so browser
+      // background-tab scheduling does not delay or starve React state updates.
+      await chrome.tabs.update(tab.id, { active: true });
       const result = await sendToTab(tab.id, {
         type: "crossdock.submitCodex",
         prompt: message.prompt,
         targetRepository,
         targetBranch,
       });
-      await chrome.tabs.update(tab.id, { active: true });
       return { ...result, providerContext: { repository: targetRepository, base_branch: targetBranch } };
     }
     case "crossdock.inspectCodex": {

--- a/tests/codex-repository-context-ui.test.js
+++ b/tests/codex-repository-context-ui.test.js
@@ -14,6 +14,18 @@ test("background snapshots repository default branch and passes frozen provider 
   assert.match(backgroundSource, /crossdock\.submitCodex[\s\S]*targetRepository[\s\S]*targetBranch/);
 });
 
+test("background activates Codex before provider-context automation", () => {
+  const start = backgroundSource.indexOf('case "crossdock.submitCodex"');
+  const end = backgroundSource.indexOf('case "crossdock.inspectCodex"');
+  const submitCase = backgroundSource.slice(start, end);
+  assert.ok(start >= 0 && end > start);
+  const ensureTab = submitCase.indexOf("const tab = await ensureCodexTab()");
+  const activate = submitCase.indexOf("await chrome.tabs.update(tab.id, { active: true })");
+  const send = submitCase.indexOf("const result = await sendToTab(tab.id");
+  assert.ok(ensureTab >= 0 && ensureTab < activate);
+  assert.ok(activate < send);
+});
+
 test("Codex submission resolves repository and branch context before writing or clicking", () => {
   const start = contentSource.indexOf("async function submitCodexPrompt");
   const end = contentSource.indexOf("async function ensureCodexRepositoryContext");


### PR DESCRIPTION
Fixes #138.

Authenticated live testing showed repository-selection latency becoming highly variable when Crossdock drove Codex from the background: roughly 11s, 27.6s, 65.3s, and eventually beyond the temporary 120s ceiling. Manual selection while Codex was foregrounded had been effectively immediate.

The background adapter currently activates the Codex tab only after `sendToTab(... crossdock.submitCodex ...)` returns, which means repository selection, branch verification, prompt mutation, submission, and all content-script polling run while Codex is backgrounded.

This change activates the Codex tab before sending the submission message. Exact repository/branch verification, fail-closed ordering, and the current bounded timeout remain unchanged for this diagnostic fix. Regression coverage verifies activation occurs after tab resolution but before provider automation begins.

After merge, authenticated live retesting should determine whether the long timeout can be reduced to a normal safety ceiling rather than serving as a workaround for background-tab scheduling.