### PR TITLE
fix: wait for Codex submit readiness

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -36,7 +36,8 @@ async function submitCodexPrompt(prompt, targetRepository, targetBranch) {
   setEditableValue(input, prompt);
 
   const beforeUrl = location.href;
-  findCodexSubmitButton(true).click();
+  const submitButton = await waitForCodexSubmitButton(5_000);
+  submitButton.click();
 
   const taskUrl = await waitForCodexSubmission({ beforeUrl, prompt });
   return { taskUrl, providerContext: { repository: targetRepository, base_branch: targetBranch } };
@@ -193,6 +194,14 @@ function findCodexPromptInput(required = true) {
   if (nodes.length > 1) throw new Error(`Codex prompt input must resolve to at most one visible element; found ${nodes.length}`);
   if (required && nodes.length !== 1) throw new Error(`Codex prompt input must resolve to exactly one visible element; found ${nodes.length}`);
   return nodes[0] ?? null;
+}
+
+async function waitForCodexSubmitButton(timeoutMs) {
+  return waitForResult(
+    () => findCodexSubmitButton(false),
+    timeoutMs,
+    "Codex submit control did not become ready after prompt entry",
+  );
 }
 
 function findCodexSubmitButton(required = true) {

--- a/tests/codex-repository-context-ui.test.js
+++ b/tests/codex-repository-context-ui.test.js
@@ -34,10 +34,12 @@ test("Codex submission resolves repository and branch context before writing or 
   const repositoryResolution = submit.indexOf("await ensureCodexRepositoryContext(targetRepository)");
   const branchResolution = submit.indexOf("await ensureCodexBranchContext(targetBranch)");
   const promptWrite = submit.indexOf("setEditableValue(input, prompt)");
-  const submitClick = submit.indexOf("findCodexSubmitButton(true).click()");
+  const submitReady = submit.indexOf("await waitForCodexSubmitButton(5_000)");
+  const submitClick = submit.indexOf("submitButton.click()");
   assert.ok(repositoryResolution >= 0 && repositoryResolution < branchResolution);
   assert.ok(branchResolution < promptWrite);
-  assert.ok(branchResolution < submitClick);
+  assert.ok(promptWrite < submitReady);
+  assert.ok(submitReady < submitClick);
 });
 
 test("repository selection uses authenticated Codex semantic controls and exact repository text", () => {
@@ -103,4 +105,12 @@ test("branch confirmation uses the same extended transition timeout", () => {
 test("provider context is returned with exact repository and frozen base branch", () => {
   assert.match(contentSource, /providerContext: \{ repository: targetRepository, base_branch: targetBranch \}/);
   assert.match(backgroundSource, /providerContext: \{ repository: targetRepository, base_branch: targetBranch \}/);
+});
+
+test("Codex submission waits boundedly for the semantic submit control to become ready", () => {
+  const start = contentSource.indexOf("async function submitCodexPrompt");
+  const end = contentSource.indexOf("async function ensureCodexRepositoryContext");
+  const submit = contentSource.slice(start, end);
+  assert.match(submit, /setEditableValue\(input, prompt\)[\s\S]*await waitForCodexSubmitButton\(5_000\)[\s\S]*submitButton\.click\(\)/);
+  assert.match(contentSource, /async function waitForCodexSubmitButton\(timeoutMs\)[\s\S]*findCodexSubmitButton\(false\)[\s\S]*Codex submit control did not become ready after prompt entry/);
 });


### PR DESCRIPTION
Fixes #140.

Authenticated live testing showed the current Codex composer already exposes the submit control as visible/enabled `button[aria-label="Submit"]`, but Crossdock queried synchronously immediately after programmatic prompt insertion.

This change:
- waits up to 5 seconds for the existing semantic submit-control discovery to resolve uniquely after prompt mutation;
- clicks only after that readiness wait succeeds;
- preserves existing semantic selectors and fail-closed ambiguity behavior;
- adds regression coverage enforcing prompt write → bounded readiness wait → click ordering.

No icon, coordinate, position, tooltip, or provider-specific visual guessing was added.