### PR TITLE
fix: resolve Codex repository via environment semantics

### DIFF
--- a/docs/testing/codex-environment-semantic-resolution.md
+++ b/docs/testing/codex-environment-semantic-resolution.md
@@ -1,0 +1,32 @@
+# Codex environment semantic resolution
+
+## Observed provider behavior
+
+Codex's environment chooser is a human-facing control with separate **Environments** and **Repositories** sections. After a repository receives an environment, the repository may disappear from **Repositories** and instead appear under **Environments** using its repository basename. For example, target `seedbed-ai/crossdock-live-target` is represented by the unique environment `crossdock-live-target` while the stale selected environment is `sb`.
+
+## Resolution rule
+
+Crossdock should interpret the visible chooser semantically rather than require a persisted machine-readable environment-to-repository mapping.
+
+For configured target `owner/repository`:
+
+1. If the selected provider context already visibly identifies the exact target, accept it.
+2. Otherwise open the environment chooser and prefer an exact visible `owner/repository` repository choice when one exists.
+3. If no exact repository choice exists, derive the repository basename (`repository`) and accept a unique visible environment choice with that exact basename.
+4. If either resolution path is ambiguous, fail closed before writing the prompt or submitting the task.
+5. After selection, require the chooser to close and the selected context to visibly identify either the exact target or the uniquely resolved environment.
+6. Select and verify the intended base branch before prompt mutation.
+7. Keep downstream task/PR repository integrity checks. Human-style chooser interpretation does not weaken mutation-boundary verification.
+
+Persisted environment mappings are not required for this ordinary path. They may be used only as fallback evidence where the visible provider UI is genuinely ambiguous, and must not override contradictory live UI evidence.
+
+## Non-goals
+
+- Do not infer choices by DOM order or screen coordinates.
+- Do not require opening **Manage environments** for an unambiguous chooser.
+- Do not treat environment display names as globally machine-readable repository identifiers.
+- Do not weaken wrong-repository detection or pre-PR integrity checks.
+
+## Regression case
+
+Given target `seedbed-ai/crossdock-live-target`, selected context `sb`, and a chooser containing a unique environment `crossdock-live-target` but no repository row `seedbed-ai/crossdock-live-target`, Crossdock selects `crossdock-live-target`, verifies the resulting visible selection, selects/verifies the intended branch, and only then writes/submits the prompt.

--- a/extension/content.js
+++ b/extension/content.js
@@ -48,29 +48,40 @@ async function ensureCodexRepositoryContext(targetRepository) {
     throw new Error("target repository must be owner/repo");
   }
 
+  const repositoryName = targetRepository.split("/").at(-1);
   const selector = findUniqueSemanticButton("View all code environments");
-  if (visibleText(selector) === targetRepository) {
-    assertCodexRepositoryContext(targetRepository);
+  const selectedContext = visibleText(selector);
+  if (selectedContext === targetRepository || selectedContext === repositoryName) {
+    assertCodexRepositoryContext(targetRepository, repositoryName);
     return;
   }
 
   selector.click();
   const dialog = await waitForControlledDialog(selector, 5_000, "Codex environment chooser did not open");
-  const candidates = exactVisibleButtonChoices(dialog, targetRepository);
+  const repositoryCandidates = exactVisibleButtonChoices(dialog, targetRepository);
+  let candidates = repositoryCandidates;
+  let expectedSelection = targetRepository;
 
-  if (candidates.length === 0) {
-    throw new Error(`Codex repository context is unresolved for target ${targetRepository}; repository is not visible in the environment chooser`);
-  }
-  if (candidates.length > 1) {
-    throw new Error(`Codex repository context is ambiguous for target ${targetRepository}; found ${candidates.length} exact repository choices`);
+  if (repositoryCandidates.length === 0) {
+    const environmentCandidates = exactVisibleButtonChoices(dialog, repositoryName);
+    if (environmentCandidates.length === 0) {
+      throw new Error(`Codex repository context is unresolved for target ${targetRepository}; neither exact repository nor matching environment is visible in the environment chooser`);
+    }
+    if (environmentCandidates.length > 1) {
+      throw new Error(`Codex repository context is ambiguous for target ${targetRepository}; found ${environmentCandidates.length} matching environment choices`);
+    }
+    candidates = environmentCandidates;
+    expectedSelection = repositoryName;
+  } else if (repositoryCandidates.length > 1) {
+    throw new Error(`Codex repository context is ambiguous for target ${targetRepository}; found ${repositoryCandidates.length} exact repository choices`);
   }
 
   candidates[0].click();
   await waitFor(() => {
     const currentSelector = findUniqueSemanticButton("View all code environments");
-    return visibleText(currentSelector) === targetRepository && currentSelector.getAttribute("aria-expanded") !== "true";
+    return visibleText(currentSelector) === expectedSelection && currentSelector.getAttribute("aria-expanded") !== "true";
   }, CODEX_CONTEXT_SELECTION_TIMEOUT_MS, `Codex repository selection was not confirmed for target ${targetRepository}`);
-  assertCodexRepositoryContext(targetRepository);
+  assertCodexRepositoryContext(targetRepository, repositoryName);
 }
 
 async function ensureCodexBranchContext(targetBranch) {
@@ -101,14 +112,14 @@ async function ensureCodexBranchContext(targetBranch) {
   assertCodexBranchContext(expected);
 }
 
-function assertCodexRepositoryContext(targetRepository) {
+function assertCodexRepositoryContext(targetRepository, repositoryName = targetRepository.split("/").at(-1)) {
   if (typeof targetRepository !== "string" || !/^[^/\s]+\/[^/\s]+$/.test(targetRepository)) {
     throw new Error("target repository must be owner/repo");
   }
 
   const environmentButton = findUniqueSemanticButton("View all code environments");
   const selectedRepository = visibleText(environmentButton);
-  if (selectedRepository === targetRepository) return;
+  if (selectedRepository === targetRepository || selectedRepository === repositoryName) return;
 
   throw new Error(`Codex repository context does not match target ${targetRepository}; selected provider context: ${selectedRepository || "none"}`);
 }

--- a/tests/codex-repository-context-ui.test.js
+++ b/tests/codex-repository-context-ui.test.js
@@ -42,11 +42,13 @@ test("Codex submission resolves repository and branch context before writing or 
   assert.ok(submitReady < submitClick);
 });
 
-test("repository selection uses authenticated Codex semantic controls and exact repository text", () => {
+test("repository selection uses authenticated Codex semantic controls and human-readable environment fallback", () => {
   assert.match(contentSource, /View all code environments/);
   assert.match(contentSource, /waitForControlledDialog/);
   assert.match(contentSource, /exactVisibleButtonChoices\(dialog, targetRepository\)/);
-  assert.match(contentSource, /repository is not visible in the environment chooser/);
+  assert.match(contentSource, /exactVisibleButtonChoices\(dialog, repositoryName\)/);
+  assert.match(contentSource, /neither exact repository nor matching environment is visible/);
+  assert.match(contentSource, /matching environment choices/);
   assert.match(contentSource, /exact repository choices/);
 });
 
@@ -113,4 +115,18 @@ test("Codex submission waits boundedly for the semantic submit control to become
   const submit = contentSource.slice(start, end);
   assert.match(submit, /setEditableValue\(input, prompt\)[\s\S]*await waitForCodexSubmitButton\(5_000\)[\s\S]*submitButton\.click\(\)/);
   assert.match(contentSource, /async function waitForCodexSubmitButton\(timeoutMs\)[\s\S]*findCodexSubmitButton\(false\)[\s\S]*Codex submit control did not become ready after prompt entry/);
+});
+
+test("repository context accepts a selected environment matching the repository basename", () => {
+  const start = contentSource.indexOf("async function ensureCodexRepositoryContext");
+  const end = contentSource.indexOf("async function ensureCodexBranchContext");
+  const repositorySelection = contentSource.slice(start, end);
+  assert.match(repositorySelection, /const repositoryName = targetRepository\.split\("\/"\)\.at\(-1\)/);
+  assert.match(repositorySelection, /selectedContext === targetRepository \|\| selectedContext === repositoryName/);
+  assert.match(repositorySelection, /expectedSelection = repositoryName/);
+});
+
+test("repository environment fallback stays fail-closed on ambiguity", () => {
+  assert.match(contentSource, /environmentCandidates\.length > 1/);
+  assert.match(contentSource, /found \$\{environmentCandidates\.length\} matching environment choices/);
 });

--- a/tests/codex-repository-context-ui.test.js
+++ b/tests/codex-repository-context-ui.test.js
@@ -58,7 +58,7 @@ test("repository confirmation re-resolves the live semantic selector after selec
   const repositorySelection = contentSource.slice(start, end);
   assert.ok(start >= 0 && end > start);
   assert.match(repositorySelection, /candidates\[0\]\.click\(\);[\s\S]*await waitFor\(\(\) => \{[\s\S]*const currentSelector = findUniqueSemanticButton\("View all code environments"\)/);
-  assert.match(repositorySelection, /visibleText\(currentSelector\) === targetRepository/);
+  assert.match(repositorySelection, /visibleText\(currentSelector\) === expectedSelection/);
   assert.match(repositorySelection, /currentSelector\.getAttribute\("aria-expanded"\) !== "true"/);
   assert.doesNotMatch(repositorySelection, /await waitFor\(\(\) => visibleText\(selector\) === targetRepository/);
 });


### PR DESCRIPTION
Fixes #143.

Authenticated live testing showed that after Codex lazily creates an environment for a repository, the exact owner/repo may disappear from the Repositories section and instead appear as a unique Environment using the repository basename.

This change follows the visible human-facing UI semantics rather than requiring a persisted machine mapping:
- prefer an exact owner/repo repository choice when present;
- otherwise fall back to a unique environment whose visible label exactly matches the repository basename;
- fail closed on zero or multiple matching environments;
- accept the resulting selected context as either the exact owner/repo or the resolved environment label;
- preserve branch verification and downstream task/PR repository integrity checks.

No DOM-order, coordinate, tooltip, or hidden-metadata inference is used.