### PR TITLE
fix: monitor concrete Codex task

### DIFF
--- a/docs/testing/codex-task-monitoring.md
+++ b/docs/testing/codex-task-monitoring.md
@@ -1,0 +1,14 @@
+# Codex task monitoring
+
+Crossdock must monitor the concrete submitted Codex task, not the generic Codex landing page.
+
+## Required behavior
+
+- Before submission, snapshot currently visible Codex task URLs.
+- After the provider accepts the prompt, resolve the concrete task URL either from navigation to a task page or from exactly one newly visible task link on the Codex landing page.
+- Persist that concrete task URL in task state.
+- Monitoring must inspect that exact task. If the single Codex tab is still on the landing page, Crossdock may navigate it to the persisted task URL without requiring the user to open the task manually.
+- Task URL discovery and navigation remain fail-closed on ambiguity.
+- Do not submit a duplicate task just because task URL discovery is delayed.
+
+This behavior is required for review-before-handoff to transition from `running` to `ready` after the task completes without manual task navigation.

--- a/extension/content.js
+++ b/extension/content.js
@@ -35,11 +35,12 @@ async function submitCodexPrompt(prompt, targetRepository, targetBranch) {
   const input = findCodexPromptInput(true);
   setEditableValue(input, prompt);
 
-  const beforeUrl = location.href;
+  const beforeTaskUrls = findCodexTaskLinks();
   const submitButton = await waitForCodexSubmitButton(5_000);
   submitButton.click();
 
-  const taskUrl = await waitForCodexSubmission({ beforeUrl, prompt });
+  const taskUrl = await waitForCodexSubmission({ beforeTaskUrls });
+  scheduleCodexTaskNavigation(taskUrl);
   return { taskUrl, providerContext: { repository: targetRepository, base_branch: targetBranch } };
 }
 
@@ -178,25 +179,51 @@ function visibleText(node) {
   return normalizeText(node?.innerText || node?.textContent || "").replace(/\0/g, "");
 }
 
-async function waitForCodexSubmission({ beforeUrl, prompt }) {
-  const deadline = Date.now() + 15_000;
+async function waitForCodexSubmission({ beforeTaskUrls }) {
+  const baseline = new Set(beforeTaskUrls);
+  const deadline = Date.now() + 30_000;
+
   while (Date.now() < deadline) {
-    if (location.href !== beforeUrl) return location.href;
+    const currentTaskUrl = canonicalCodexTaskUrl(location.href);
+    if (currentTaskUrl) return currentTaskUrl;
 
-    const currentInput = findCodexPromptInput(false);
-    const currentValue = currentInput ? editableValue(currentInput) : "";
-    const composerNoLongerContainsPrompt = !currentInput || currentValue !== prompt;
-    const submitStillAvailable = Boolean(findCodexSubmitButton(false));
+    const newTaskUrls = [...new Set(
+      findCodexTaskLinks().filter((url) => !baseline.has(url)),
+    )];
 
-    // Codex may transition in place before assigning a task URL. Require both
-    // the submitted prompt to leave the composer and the submit/start control
-    // to disappear before claiming that submission succeeded.
-    if (composerNoLongerContainsPrompt && !submitStillAvailable) return location.href;
+    if (newTaskUrls.length > 1) {
+      throw new Error(`Codex task submission is ambiguous; found ${newTaskUrls.length} new concrete task URLs`);
+    }
+    if (newTaskUrls.length === 1) return newTaskUrls[0];
 
     await sleep(100);
   }
 
-  throw new Error("Codex task submission was not confirmed; the task may still be waiting in the composer");
+  throw new Error("Codex task submission was not confirmed with a concrete task URL");
+}
+
+function canonicalCodexTaskUrl(value) {
+  try {
+    const url = new URL(value, location.origin);
+    if (url.origin !== location.origin) return null;
+    if (!/^\/codex\/cloud\/tasks\/[^/?#]+$/.test(url.pathname)) return null;
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return null;
+  }
+}
+
+function findCodexTaskLinks() {
+  return [...document.querySelectorAll('a[href*="/codex/cloud/tasks/"]')]
+    .filter(isVisible)
+    .map((anchor) => canonicalCodexTaskUrl(anchor.href))
+    .filter(Boolean);
+}
+
+function scheduleCodexTaskNavigation(taskUrl) {
+  setTimeout(() => {
+    if (canonicalCodexTaskUrl(location.href) !== taskUrl) location.assign(taskUrl);
+  }, 0);
 }
 
 function findCodexPromptInput(required = true) {

--- a/tests/codex-repository-context-ui.test.js
+++ b/tests/codex-repository-context-ui.test.js
@@ -130,3 +130,33 @@ test("repository environment fallback stays fail-closed on ambiguity", () => {
   assert.match(contentSource, /environmentCandidates\.length > 1/);
   assert.match(contentSource, /found \$\{environmentCandidates\.length\} matching environment choices/);
 });
+
+test("Codex submission requires a concrete task URL before reporting success", () => {
+  const submitStart = contentSource.indexOf("async function submitCodexPrompt");
+  const submitEnd = contentSource.indexOf("async function ensureCodexRepositoryContext");
+  const submit = contentSource.slice(submitStart, submitEnd);
+
+  assert.match(submit, /const beforeTaskUrls = findCodexTaskLinks\(\)/);
+  assert.match(
+    submit,
+    /submitButton\.click\(\)[\s\S]*await waitForCodexSubmission\(\{ beforeTaskUrls \}\)[\s\S]*scheduleCodexTaskNavigation\(taskUrl\)/,
+  );
+
+  const waitStart = contentSource.indexOf("async function waitForCodexSubmission");
+  const waitEnd = contentSource.indexOf("function findCodexPromptInput");
+  const wait = contentSource.slice(waitStart, waitEnd);
+
+  assert.match(wait, /canonicalCodexTaskUrl\(location\.href\)/);
+  assert.match(wait, /findCodexTaskLinks\(\)\.filter/);
+  assert.match(wait, /new concrete task URLs/);
+  assert.match(wait, /not confirmed with a concrete task URL/);
+  assert.doesNotMatch(wait, /return location\.href/);
+});
+
+test("Codex concrete task discovery is same-origin, semantic, and schedules task-page navigation", () => {
+  assert.match(contentSource, /a\[href\*="\/codex\/cloud\/tasks\/"\]/);
+  assert.match(contentSource, /url\.origin !== location\.origin/);
+  assert.match(contentSource, /\^\\\/codex\\\/cloud\\\/tasks\\\//);
+  assert.match(contentSource, /function scheduleCodexTaskNavigation\(taskUrl\)/);
+  assert.match(contentSource, /location\.assign\(taskUrl\)/);
+});


### PR DESCRIPTION
Fixes #145.

Authenticated live testing showed Crossdock could treat the Codex landing page as a submitted task and then wait indefinitely for Create PR until the user manually opened the task.

This change:
- snapshots visible concrete Codex task URLs before submission;
- requires submission to resolve a concrete `/codex/cloud/tasks/...` URL;
- fails closed on multiple newly visible task URLs;
- rejects the landing page as a task identity;
- schedules navigation to the resolved task page so monitoring no longer depends on a user click;
- adds regression coverage for concrete task URL discovery and navigation.

Local validation reported by the user: 205/205 tests passed, `npm run check` passed, markdown links passed, and `git diff --check` passed.