### PR TITLE
fix: reset Codex composer and preserve update branch

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -30,16 +30,12 @@ async function handleMessage(message) {
         throw new Error("target repository must be configured as owner/repo before Codex submission");
       }
       const serviceUrl = stored.dashboard?.["service-url"];
-      const snapshot = await postServiceJson({
-        path: "/repository/snapshot",
-        body: { target_repository: targetRepository },
-        preference: serviceUrl,
+      const targetBranch = await resolveSubmissionBranch({
+        targetRepository,
+        pullRequest: stored.dashboard?.["pull-request"],
+        serviceUrl,
       });
-      if (snapshot.repository !== targetRepository || typeof snapshot.default_branch !== "string" || !snapshot.default_branch.trim()) {
-        throw new Error("target repository snapshot did not return the configured repository and default branch");
-      }
-      const targetBranch = snapshot.default_branch.trim();
-      const tab = await ensureCodexTab();
+      const tab = await ensureCodexComposerTab();
       // Codex repository/environment transitions are provider UI work. Keep the
       // provider tab foregrounded before driving those controls so browser
       // background-tab scheduling does not delay or starve React state updates.
@@ -91,6 +87,32 @@ async function handleMessage(message) {
   }
 }
 
+async function resolveSubmissionBranch({ targetRepository, pullRequest, serviceUrl }) {
+  const rawPullRequest = typeof pullRequest === "string" ? pullRequest.trim() : "";
+  if (rawPullRequest) {
+    if (!/^\d+$/.test(rawPullRequest) || Number(rawPullRequest) <= 0) throw new Error("existing pull request must be a positive integer");
+    const snapshot = await postServiceJson({
+      path: "/pr/snapshot",
+      body: { target_repository: targetRepository, pull_request: Number(rawPullRequest) },
+      preference: serviceUrl,
+    });
+    if (snapshot.repository !== targetRepository || typeof snapshot.working_branch !== "string" || !snapshot.working_branch.trim()) {
+      throw new Error("existing pull request snapshot did not return the configured repository and working branch");
+    }
+    return snapshot.working_branch.trim();
+  }
+
+  const snapshot = await postServiceJson({
+    path: "/repository/snapshot",
+    body: { target_repository: targetRepository },
+    preference: serviceUrl,
+  });
+  if (snapshot.repository !== targetRepository || typeof snapshot.default_branch !== "string" || !snapshot.default_branch.trim()) {
+    throw new Error("target repository snapshot did not return the configured repository and default branch");
+  }
+  return snapshot.default_branch.trim();
+}
+
 async function openDashboard() {
   const dashboards = (await chrome.tabs.query({})).filter((tab) => tab.url === DASHBOARD_URL);
   if (dashboards.length > 1) throw new Error(`dashboard tab is ambiguous; found ${dashboards.length}`);
@@ -110,6 +132,15 @@ async function ensureCodexTab() {
   if (tabs.length > 1) throw new Error(`Codex tab is ambiguous; found ${tabs.length}`);
   if (tabs.length === 1) return tabs[0];
   const tab = await chrome.tabs.create({ url: CODEX_URL, active: true });
+  await waitForTabComplete(tab.id);
+  return chrome.tabs.get(tab.id);
+}
+
+async function ensureCodexComposerTab() {
+  const tab = await ensureCodexTab();
+  const current = new URL(tab.url);
+  if (current.origin === new URL(CODEX_URL).origin && current.pathname === new URL(CODEX_URL).pathname) return tab;
+  await chrome.tabs.update(tab.id, { url: CODEX_URL, active: true });
   await waitForTabComplete(tab.id);
   return chrome.tabs.get(tab.id);
 }

--- a/tests/codex-repository-context-ui.test.js
+++ b/tests/codex-repository-context-ui.test.js
@@ -14,12 +14,12 @@ test("background snapshots repository default branch and passes frozen provider 
   assert.match(backgroundSource, /crossdock\.submitCodex[\s\S]*targetRepository[\s\S]*targetBranch/);
 });
 
-test("background activates Codex before provider-context automation", () => {
+test("background activates the composer-ready Codex tab before provider-context automation", () => {
   const start = backgroundSource.indexOf('case "crossdock.submitCodex"');
   const end = backgroundSource.indexOf('case "crossdock.inspectCodex"');
   const submitCase = backgroundSource.slice(start, end);
   assert.ok(start >= 0 && end > start);
-  const ensureTab = submitCase.indexOf("const tab = await ensureCodexTab()");
+  const ensureTab = submitCase.indexOf("const tab = await ensureCodexComposerTab()");
   const activate = submitCase.indexOf("await chrome.tabs.update(tab.id, { active: true })");
   const send = submitCase.indexOf("const result = await sendToTab(tab.id");
   assert.ok(ensureTab >= 0 && ensureTab < activate);

--- a/tests/codex-submission-routing.test.js
+++ b/tests/codex-submission-routing.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const backgroundSource = await readFile(new URL("../extension/background.js", import.meta.url), "utf8");
+
+test("new Codex submissions return an existing task tab to the composer before provider automation", () => {
+  const start = backgroundSource.indexOf('case "crossdock.submitCodex"');
+  const end = backgroundSource.indexOf('case "crossdock.inspectCodex"');
+  const submitCase = backgroundSource.slice(start, end);
+
+  assert.ok(start >= 0 && end > start);
+  assert.match(submitCase, /const tab = await ensureCodexComposerTab\(\)/);
+  assert.match(backgroundSource, /const CODEX_URL = "https:\/\/chatgpt\.com\/codex\/cloud"/);
+  assert.match(backgroundSource, /async function ensureCodexComposerTab\(\)[\s\S]*chrome\.tabs\.update\(tab\.id, \{ url: CODEX_URL, active: true \}\)[\s\S]*await waitForTabComplete\(tab\.id\)/);
+
+  const composer = submitCase.indexOf("const tab = await ensureCodexComposerTab()");
+  const activate = submitCase.indexOf("await chrome.tabs.update(tab.id, { active: true })");
+  const send = submitCase.indexOf("const result = await sendToTab(tab.id");
+  assert.ok(composer >= 0 && composer < activate);
+  assert.ok(activate < send);
+});
+
+test("existing PR updates resolve the Codex branch from the PR working branch", () => {
+  assert.match(backgroundSource, /async function resolveSubmissionBranch/);
+  assert.match(backgroundSource, /path: "\/pr\/snapshot"/);
+  assert.match(backgroundSource, /pull_request: Number\(rawPullRequest\)/);
+  assert.match(backgroundSource, /snapshot\.working_branch/);
+  assert.match(backgroundSource, /return snapshot\.working_branch\.trim\(\)/);
+});
+
+test("initial Codex submissions still resolve the repository default branch", () => {
+  assert.match(backgroundSource, /path: "\/repository\/snapshot"/);
+  assert.match(backgroundSource, /snapshot\.default_branch/);
+  assert.match(backgroundSource, /return snapshot\.default_branch\.trim\(\)/);
+});
+
+test("submission branch is resolved before Codex page navigation or prompt mutation", () => {
+  const start = backgroundSource.indexOf('case "crossdock.submitCodex"');
+  const end = backgroundSource.indexOf('case "crossdock.inspectCodex"');
+  const submitCase = backgroundSource.slice(start, end);
+
+  const branch = submitCase.indexOf("const targetBranch = await resolveSubmissionBranch");
+  const composer = submitCase.indexOf("const tab = await ensureCodexComposerTab()");
+  const send = submitCase.indexOf("const result = await sendToTab(tab.id");
+  assert.ok(branch >= 0 && branch < composer);
+  assert.ok(composer < send);
+});


### PR DESCRIPTION
Fixes #149 and #150.

This change makes new Crossdock Codex submissions self-contained across repeated tasks:

- if the existing Codex tab is still on a completed concrete task page, Crossdock navigates it back to `/codex/cloud` and waits for load completion before provider-context automation;
- initial/new-PR submissions continue to use the repository default branch;
- existing-PR update submissions resolve and use the PR snapshot's exact `working_branch` instead of the repository default branch;
- branch resolution happens before Codex page navigation or prompt mutation;
- existing downstream head-change verification remains unchanged.

Regression coverage was added for composer reset, update working-branch routing, initial default-branch routing, and ordering.