### PR TITLE
fix: wait for Codex composer readiness

### DIFF
--- a/docs/testing/codex-composer-readiness.md
+++ b/docs/testing/codex-composer-readiness.md
@@ -1,0 +1,25 @@
+# Codex composer readiness gate
+
+Authenticated live testing showed that Chrome tab load completion is not equivalent to Codex composer readiness. After Crossdock navigated a completed task tab back to `/codex/cloud`, the browser reported the page loaded before React had rendered the semantic repository/environment selector. Crossdock then attempted provider-context resolution too early and failed with zero visible controls.
+
+## Required behavior
+
+Before any provider-context lookup or prompt mutation for a new task, Crossdock must:
+
+1. own/resolve the intended Codex tab;
+2. foreground it;
+3. navigate it to `/codex/cloud` when necessary;
+4. wait for browser load completion when navigation occurred;
+5. poll a non-mutating content-script readiness check for the visible semantic control `aria-label="View all code environments"`;
+6. proceed only when exactly one such visible, enabled control exists;
+7. fail clearly after a bounded timeout if semantic readiness never arrives.
+
+The readiness check must not write the prompt, change repository/branch selection, or submit a task. It exists only to distinguish browser load completion from application-level UI readiness.
+
+## Safety
+
+- Zero controls means not ready yet, not immediate failure while inside the bounded readiness window.
+- Multiple matching controls remain an ambiguity error and fail closed.
+- The Codex tab remains foregrounded during the readiness wait because authenticated testing previously showed background React transitions can be delayed or starved.
+- No arbitrary fixed sleep is used.
+- Existing repository, branch, task, and PR integrity checks remain unchanged.

--- a/extension/background.js
+++ b/extension/background.js
@@ -139,10 +139,34 @@ async function ensureCodexTab() {
 async function ensureCodexComposerTab() {
   const tab = await ensureCodexTab();
   const current = new URL(tab.url);
-  if (current.origin === new URL(CODEX_URL).origin && current.pathname === new URL(CODEX_URL).pathname) return tab;
-  await chrome.tabs.update(tab.id, { url: CODEX_URL, active: true });
-  await waitForTabComplete(tab.id);
+
+  if (current.origin !== new URL(CODEX_URL).origin || current.pathname !== new URL(CODEX_URL).pathname) {
+    await chrome.tabs.update(tab.id, { url: CODEX_URL, active: true });
+    await waitForTabComplete(tab.id);
+  } else {
+    await chrome.tabs.update(tab.id, { active: true });
+  }
+
+  await waitForCodexComposerReady(tab.id);
   return chrome.tabs.get(tab.id);
+}
+
+async function waitForCodexComposerReady(tabId) {
+  const deadline = Date.now() + 30_000;
+
+  while (Date.now() < deadline) {
+    try {
+      const result = await sendToTab(tabId, { type: "crossdock.inspectCodexComposer" });
+      if (result?.ready === true) return;
+    } catch (error) {
+      if (error.message?.includes("ambiguous")) throw error;
+      // During navigation/hydration the content script or semantic control may
+      // not be ready yet. Retry only within this bounded readiness window.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  throw new Error("timed out waiting for Codex composer semantic controls");
 }
 
 async function activateOrCreate(url, codex) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -11,6 +11,7 @@ async function handleMessage(message) {
   switch (message.type) {
     case "crossdock.capturePrompt": return { assistantResponse: captureLatestAssistantResponse(), url: location.href };
     case "crossdock.submitCodex": return submitCodexPrompt(message.prompt, message.targetRepository, message.targetBranch);
+    case "crossdock.inspectCodexComposer": return inspectCodexComposer();
     case "crossdock.inspectCodex": return inspectCodexTask();
     case "crossdock.findPrUrls": return { prUrls: findPullRequestLinks(message.targetRepository) };
     case "crossdock.prepareCreatePr": return prepareCreatePr(message.captureReport !== false);
@@ -266,6 +267,20 @@ function findCodexSubmitButton(required = true) {
   if (buttons.length > 1) throw new Error(`Codex submit control is ambiguous; found ${buttons.length} label candidates`);
   if (required && buttons.length !== 1) throw new Error(`required Codex submit control not found; expected one of: ${labels.join(", ")}`);
   return buttons[0] ?? null;
+}
+
+function inspectCodexComposer() {
+  requireCodexPage();
+  const controls = [...document.querySelectorAll(
+    'button[aria-label="View all code environments"], [role="button"][aria-label="View all code environments"]',
+  )]
+    .filter(isVisible)
+    .filter(isEnabled);
+
+  if (controls.length > 1) {
+    throw new Error(`Codex composer readiness is ambiguous; found ${controls.length} visible repository/environment controls`);
+  }
+  return { ready: controls.length === 1 };
 }
 
 function inspectCodexTask() {

--- a/tests/codex-submission-routing.test.js
+++ b/tests/codex-submission-routing.test.js
@@ -4,7 +4,7 @@ import { readFile } from "node:fs/promises";
 
 const backgroundSource = await readFile(new URL("../extension/background.js", import.meta.url), "utf8");
 
-test("new Codex submissions return an existing task tab to the composer before provider automation", () => {
+test("new Codex submissions return to the composer and await semantic readiness before provider automation", () => {
   const start = backgroundSource.indexOf('case "crossdock.submitCodex"');
   const end = backgroundSource.indexOf('case "crossdock.inspectCodex"');
   const submitCase = backgroundSource.slice(start, end);
@@ -12,7 +12,12 @@ test("new Codex submissions return an existing task tab to the composer before p
   assert.ok(start >= 0 && end > start);
   assert.match(submitCase, /const tab = await ensureCodexComposerTab\(\)/);
   assert.match(backgroundSource, /const CODEX_URL = "https:\/\/chatgpt\.com\/codex\/cloud"/);
-  assert.match(backgroundSource, /async function ensureCodexComposerTab\(\)[\s\S]*chrome\.tabs\.update\(tab\.id, \{ url: CODEX_URL, active: true \}\)[\s\S]*await waitForTabComplete\(tab\.id\)/);
+  assert.match(
+    backgroundSource,
+    /async function ensureCodexComposerTab\(\)[\s\S]*chrome\.tabs\.update\(tab\.id, \{ url: CODEX_URL, active: true \}\)[\s\S]*await waitForTabComplete\(tab\.id\)[\s\S]*await waitForCodexComposerReady\(tab\.id\)/,
+  );
+  assert.match(backgroundSource, /type: "crossdock\.inspectCodexComposer"/);
+  assert.match(backgroundSource, /timed out waiting for Codex composer semantic controls/);
 
   const composer = submitCase.indexOf("const tab = await ensureCodexComposerTab()");
   const activate = submitCase.indexOf("await chrome.tabs.update(tab.id, { active: true })");
@@ -45,4 +50,20 @@ test("submission branch is resolved before Codex page navigation or prompt mutat
   const send = submitCase.indexOf("const result = await sendToTab(tab.id");
   assert.ok(branch >= 0 && branch < composer);
   assert.ok(composer < send);
+});
+
+
+test("composer readiness inspection is non-mutating and semantic", async () => {
+  const contentSource = await readFile(new URL("../extension/content.js", import.meta.url), "utf8");
+
+  assert.match(contentSource, /case "crossdock\.inspectCodexComposer": return inspectCodexComposer\(\)/);
+  const start = contentSource.indexOf("function inspectCodexComposer()");
+  const end = contentSource.indexOf("function inspectCodexTask()");
+  const inspection = contentSource.slice(start, end);
+
+  assert.match(inspection, /View all code environments/);
+  assert.match(inspection, /controls\.length === 1/);
+  assert.match(inspection, /controls\.length > 1/);
+  assert.doesNotMatch(inspection, /click\(/);
+  assert.doesNotMatch(inspection, /setEditableValue/);
 });


### PR DESCRIPTION
Fixes #152.

Authenticated live testing showed that automatic navigation to `/codex/cloud` completed at the browser level before the React composer had rendered the semantic repository/environment control. Crossdock then failed immediately with `found 0`.

This change:
- adds a non-mutating `crossdock.inspectCodexComposer` content-script probe;
- treats exactly one visible `aria-label="View all code environments"` control as composer readiness;
- fails closed on ambiguous readiness controls;
- keeps the Codex tab foregrounded;
- waits boundedly for semantic readiness after navigation before provider-context automation;
- avoids arbitrary fixed sleeps;
- adds regression coverage for the readiness boundary.

Local validation reported by the user: 210/210 tests passed, `npm run check` passed, markdown links passed, and `git diff --check` passed.