### PR TITLE
fix: wait for Codex branch options

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -97,16 +97,15 @@ async function ensureCodexBranchContext(targetBranch) {
 
   selector.click();
   const dialog = await waitForControlledDialog(selector, 5_000, "Codex branch chooser did not open");
-  const candidates = exactVisibleButtonChoices(dialog, expected);
+  const candidate = await waitForUniqueExactVisibleButtonChoice(
+    dialog,
+    expected,
+    5_000,
+    `Codex branch context is unresolved for target ${expected}; branch did not become visible in the branch chooser`,
+    `Codex branch context is ambiguous for target ${expected}`,
+  );
 
-  if (candidates.length === 0) {
-    throw new Error(`Codex branch context is unresolved for target ${expected}; branch is not visible in the branch chooser`);
-  }
-  if (candidates.length > 1) {
-    throw new Error(`Codex branch context is ambiguous for target ${expected}; found ${candidates.length} exact branch choices`);
-  }
-
-  candidates[0].click();
+  candidate.click();
   await waitFor(() => {
     const currentSelector = findUniqueSemanticButton("Search for your branch");
     return visibleText(currentSelector) === expected && currentSelector.getAttribute("aria-expanded") !== "true";
@@ -138,6 +137,17 @@ function exactVisibleButtonChoices(scope, expectedText) {
     .filter(isVisible)
     .filter(isEnabled)
     .filter((node) => visibleText(node) === expectedText);
+}
+
+async function waitForUniqueExactVisibleButtonChoice(scope, expectedText, timeoutMs, unresolvedMessage, ambiguousMessage) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const candidates = exactVisibleButtonChoices(scope, expectedText);
+    if (candidates.length > 1) throw new Error(`${ambiguousMessage}; found ${candidates.length} exact choices`);
+    if (candidates.length === 1) return candidates[0];
+    await sleep(50);
+  }
+  throw new Error(unresolvedMessage);
 }
 
 function findUniqueSemanticButton(ariaLabel) {

--- a/tests/codex-repository-context-ui.test.js
+++ b/tests/codex-repository-context-ui.test.js
@@ -77,8 +77,8 @@ test("repository confirmation allows observed slow provider transitions to settl
 test("branch selection uses authenticated Codex semantic controls and exact branch text", () => {
   assert.match(contentSource, /Search for your branch/);
   assert.match(contentSource, /ensureCodexBranchContext/);
-  assert.match(contentSource, /exactVisibleButtonChoices\(dialog, expected\)/);
-  assert.match(contentSource, /branch is not visible in the branch chooser/);
+  assert.match(contentSource, /waitForUniqueExactVisibleButtonChoice\(/);
+  assert.match(contentSource, /branch did not become visible in the branch chooser/);
   assert.match(contentSource, /Codex branch selection was not confirmed/);
   assert.match(contentSource, /selected provider branch/);
 });
@@ -159,4 +159,17 @@ test("Codex concrete task discovery is same-origin, semantic, and schedules task
   assert.match(contentSource, /\^\\\/codex\\\/cloud\\\/tasks\\\//);
   assert.match(contentSource, /function scheduleCodexTaskNavigation\(taskUrl\)/);
   assert.match(contentSource, /location\.assign\(taskUrl\)/);
+});
+
+test("branch chooser waits for delayed exact option rendering before resolving", () => {
+  const start = contentSource.indexOf("async function ensureCodexBranchContext");
+  const end = contentSource.indexOf("function assertCodexRepositoryContext");
+  const branchSelection = contentSource.slice(start, end);
+
+  assert.match(branchSelection, /await waitForUniqueExactVisibleButtonChoice\([\s\S]*dialog,[\s\S]*expected,[\s\S]*5_000/);
+  assert.match(contentSource, /async function waitForUniqueExactVisibleButtonChoice/);
+  assert.match(contentSource, /exactVisibleButtonChoices\(scope, expectedText\)/);
+  assert.match(contentSource, /candidates\.length > 1/);
+  assert.match(contentSource, /candidates\.length === 1/);
+  assert.match(contentSource, /await sleep\(50\)/);
 });

--- a/tests/codex-repository-context-ui.test.js
+++ b/tests/codex-repository-context-ui.test.js
@@ -88,7 +88,7 @@ test("branch confirmation re-resolves the live semantic selector after selection
   const end = contentSource.indexOf("function assertCodexRepositoryContext");
   const branchSelection = contentSource.slice(start, end);
   assert.ok(start >= 0 && end > start);
-  assert.match(branchSelection, /candidates\[0\]\.click\(\);[\s\S]*await waitFor\(\(\) => \{[\s\S]*const currentSelector = findUniqueSemanticButton\("Search for your branch"\)/);
+  assert.match(branchSelection, /candidate\.click\(\);[\s\S]*await waitFor\(\(\) => \{[\s\S]*const currentSelector = findUniqueSemanticButton\("Search for your branch"\)/);
   assert.match(branchSelection, /visibleText\(currentSelector\) === expected/);
   assert.match(branchSelection, /currentSelector\.getAttribute\("aria-expanded"\) !== "true"/);
   assert.doesNotMatch(branchSelection, /await waitFor\(\(\) => visibleText\(selector\) === expected/);


### PR DESCRIPTION
Fixes #155.

Authenticated live testing showed the branch chooser shell could become visible before its branch options rendered. Crossdock then declared the exact target branch unresolved even though the branch appeared moments later.

This change:
- waits boundedly for an exact visible branch option after the chooser opens;
- returns immediately once exactly one matching option appears;
- fails closed if multiple exact matches appear;
- fails clearly if the branch never becomes visible within the bounded window;
- preserves the existing exact-text branch selection and post-click confirmation;
- adds regression coverage for delayed option rendering.