### PR TITLE
Fix existing-PR update publication semantics

### DIFF
--- a/docs/testing/update-provider-action-semantics.md
+++ b/docs/testing/update-provider-action-semantics.md
@@ -1,0 +1,39 @@
+# Existing-PR update provider action semantics
+
+## Live observation
+
+An authenticated update task was submitted against the exact existing PR working branch `codex/add-crossdock-live-test.txt-file`. Codex completed the requested one-line addition correctly, but the completed task exposed **Create PR** rather than **Update branch**. Crossdock therefore remained in `running` because it treated the provider button label as the update-mode readiness contract.
+
+## Principle
+
+Crossdock owns the work-item meaning; the provider owns its UI vocabulary. An existing-PR update must not be classified from whether Codex says **Create PR** or **Update branch**.
+
+GitHub state is authoritative for update success.
+
+## Required flow
+
+1. At task creation, snapshot the existing PR's exact repository, working branch, and head SHA.
+2. Submit Codex against that exact working branch.
+3. A completed update task is ready when Codex exposes exactly one supported publication action: **Update branch** or **Create PR**.
+4. Before invoking that action, re-read the existing PR snapshot and require:
+   - the same repository;
+   - the same PR number;
+   - the same working branch;
+   - the same pre-update head SHA.
+5. Snapshot visible PR evidence before the provider mutation.
+6. Capture the Codex report, then invoke the one supported publication action exactly once.
+7. After invocation, require the existing PR head SHA to advance while the working branch remains unchanged.
+8. Inspect newly visible PR evidence. The expected existing PR URL is permitted; a newly visible different PR is an integrity failure.
+9. On success, publish the immutable update task record and configured update provenance comment without rewriting the original PR body.
+10. Never retry the provider publication action after it has been invoked.
+
+## Failure behavior
+
+An unexpected new PR, repository mismatch, working-branch mismatch, stale pre-action head, or ambiguous provider action is a terminal integrity failure. A delayed existing-PR head update may be polled after the provider action without invoking the action again.
+
+## Non-goals
+
+- Do not infer update semantics from provider button labels.
+- Do not manually rescue a provider-created PR into the intended PR.
+- Do not weaken repository/branch/PR integrity checks.
+- Do not require the user to click Codex publication controls directly.

--- a/docs/testing/update-provider-action-semantics.md
+++ b/docs/testing/update-provider-action-semantics.md
@@ -37,3 +37,7 @@ An unexpected new PR, repository mismatch, working-branch mismatch, stale pre-ac
 - Do not manually rescue a provider-created PR into the intended PR.
 - Do not weaken repository/branch/PR integrity checks.
 - Do not require the user to click Codex publication controls directly.
+
+## Implementation note
+
+The first local patch script aborted before writing any files because it relied on an exact multi-line source match for `finalizeUpdate()`. The script performs file writes only after all source transformations succeed, so this failure should leave the local working tree unchanged. The retry should replace whole functions by function boundaries rather than matching brittle internal whitespace or nearby text.

--- a/extension/background.js
+++ b/extension/background.js
@@ -76,7 +76,21 @@ async function handleMessage(message) {
     }
     case "crossdock.applyBranchUpdate": {
       const tab = await findChatGptTab(true);
-      return sendToTab(tab.id, { type: "crossdock.prepareBranchUpdate", captureReport: message.captureReport !== false });
+      const discovery = { beforePrUrls: await snapshotPrEvidence(tab.id) };
+      const prepared = await sendToTab(tab.id, {
+        type: "crossdock.prepareBranchUpdate",
+        captureReport: message.captureReport !== false,
+      });
+      return { ...prepared, discovery };
+    }
+    case "crossdock.inspectUpdatePrEvidence": {
+      const tab = await findChatGptTab(true);
+      return inspectUpdatePrEvidence({
+        tabId: tab.id,
+        targetRepository: message.targetRepository,
+        pullRequest: message.pullRequest,
+        discovery: message.discovery,
+      });
     }
     case "crossdock.openChatGPT": return activateOrCreate(CHATGPT_URL, false);
     case "crossdock.openCodex": return activateOrCreate(CODEX_URL, true);
@@ -241,6 +255,33 @@ async function snapshotPrEvidence(tabId) {
 function wrongRepositoryPrMessage(targetRepository, urls) {
   const repositories = [...new Set(urls.map(repositoryFromGitHubPrUrl))];
   return `created PR integrity failure: expected repository ${targetRepository}, but new PR evidence appeared in ${repositories.join(", ")}: ${urls.join(", ")}`;
+}
+
+async function inspectUpdatePrEvidence({ tabId, targetRepository, pullRequest, discovery }) {
+  if (!Number.isInteger(pullRequest) || pullRequest <= 0) {
+    throw new Error("existing pull request must be a positive integer");
+  }
+
+  const evidence = await findNewPrEvidence({ tabId, targetRepository, discovery });
+  if (evidence.wrongRepository.length) {
+    const repositories = [...new Set(evidence.wrongRepository.map(repositoryFromGitHubPrUrl))];
+    return {
+      integrityError: `update PR integrity failure: expected repository ${targetRepository}, but new PR evidence appeared in ${repositories.join(", ")}: ${evidence.wrongRepository.join(", ")}`,
+    };
+  }
+
+  const expectedPrUrl = canonicalPrUrl(
+    `https://github.com/${targetRepository}/pull/${pullRequest}`,
+    targetRepository,
+  );
+  const unexpectedTarget = evidence.target.filter((url) => url !== expectedPrUrl);
+  if (unexpectedTarget.length) {
+    return {
+      integrityError: `update PR integrity failure: expected existing PR ${expectedPrUrl}, but new target-repository PR evidence appeared: ${unexpectedTarget.join(", ")}`,
+    };
+  }
+
+  return { integrityError: null };
 }
 
 function canonicalPrUrl(value, targetRepository) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -295,7 +295,11 @@ function inspectCodexComposer() {
 
 function inspectCodexTask() {
   requireCodexPage();
-  return { taskUrl: location.href, createPrAvailable: Boolean(findButton(["Create PR"], false)), updateBranchAvailable: Boolean(findButton(["Update branch"], false)) };
+  return {
+    taskUrl: location.href,
+    createPrAvailable: Boolean(findButton(["Create PR"], false)),
+    updateBranchAvailable: Boolean(findButton(["Update branch"], false)),
+  };
 }
 
 function prepareCreatePr(captureReport = true) {
@@ -308,9 +312,19 @@ function prepareCreatePr(captureReport = true) {
 
 function prepareBranchUpdate(captureReport = true) {
   requireCodexPage();
-  const result = { taskUrl: location.href };
+
+  const actions = [
+    { providerAction: "update_branch", button: findButton(["Update branch"], false) },
+    { providerAction: "create_pr", button: findButton(["Create PR"], false) },
+  ].filter(({ button }) => Boolean(button));
+
+  if (actions.length !== 1) {
+    throw new Error(`Codex update publication action must resolve to exactly one supported control; found ${actions.length}`);
+  }
+
+  const result = { taskUrl: location.href, providerAction: actions[0].providerAction };
   if (captureReport) result.report = captureCodexReport();
-  findButton(["Update branch"], true).click();
+  actions[0].button.click();
   return result;
 }
 

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -88,7 +88,7 @@
       <button id="capture">Capture prompt</button>
       <button id="submit" class="primary">Create Codex task</button>
       <button id="finalize-initial">Finalize new PR</button>
-      <button id="finalize-update">Finalize branch update</button>
+      <button id="finalize-update">Finalize PR update</button>
     </section>
 
     <label class="prompt">Captured prompt <textarea id="prompt" rows="10" readonly></textarea></label>

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -69,6 +69,16 @@ $("submit").addEventListener("click", run(async () => {
     ? await publish("/pr/snapshot", { target_repository: repository, pull_request: prNumber }, serviceUrl)
     : null;
 
+  if (initialSnapshot && (
+    initialSnapshot.repository !== repository ||
+    typeof initialSnapshot.working_branch !== "string" ||
+    !initialSnapshot.working_branch.trim() ||
+    typeof initialSnapshot.head_sha !== "string" ||
+    !initialSnapshot.head_sha.trim()
+  )) {
+    throw new Error("existing PR snapshot did not return the configured repository, working branch, and head SHA");
+  }
+
   const pending = {
     task_id: `crossdock-${crypto.randomUUID()}`,
     created_at: new Date().toISOString(),
@@ -84,6 +94,7 @@ $("submit").addEventListener("click", run(async () => {
     storage,
     pull_request: prNumber,
     initial_head_sha: initialSnapshot?.head_sha ?? null,
+    initial_working_branch: initialSnapshot?.working_branch?.trim() ?? null,
     phase: "submitting",
   };
 
@@ -92,9 +103,14 @@ $("submit").addEventListener("click", run(async () => {
   await persist();
 
   const result = await send({ type: "crossdock.submitCodex", prompt });
-  taskState = { ...pending, task_url: result.taskUrl, phase: "running" };
+  taskState = {
+    ...pending,
+    task_url: result.taskUrl,
+    provider_branch: result.providerContext?.base_branch ?? null,
+    phase: "running",
+  };
   await saveTaskState();
-  setStatus(`Task submitted. Monitoring for ${mode === "initial" ? "Create PR" : "Update branch"} readiness…`);
+  setStatus(`Task submitted. Monitoring for ${mode === "initial" ? "Create PR" : "provider publication"} readiness…`);
   void monitorTask();
 }));
 
@@ -120,6 +136,11 @@ async function monitorTask() {
     while (taskState) {
       if (taskState.phase === "pr-create-integrity-error") {
         setStatus(`PR creation integrity failure: ${taskState.pr_integrity_error}`, true);
+        return;
+      }
+
+      if (taskState.phase === "pr-update-integrity-error") {
+        setStatus(`PR update integrity failure: ${taskState.pr_integrity_error}`, true);
         return;
       }
 
@@ -165,7 +186,11 @@ async function monitorTask() {
 
       try {
         const state = await send({ type: "crossdock.inspectCodex" });
-        const ready = taskState.mode === "initial" ? state.createPrAvailable : state.updateBranchAvailable;
+        const updateActionCount = Number(Boolean(state.updateBranchAvailable)) + Number(Boolean(state.createPrAvailable));
+        if (taskState.mode === "update" && updateActionCount > 1) {
+          throw new Error(`Codex update publication action is ambiguous; found ${updateActionCount} supported controls`);
+        }
+        const ready = taskState.mode === "initial" ? state.createPrAvailable : updateActionCount === 1;
         if (ready) {
           taskState.phase = "ready";
           await saveTaskState();
@@ -174,10 +199,10 @@ async function monitorTask() {
             else await finalizeUpdate();
             continue;
           }
-          setStatus(`Task is ready. Review the task and choose ${taskState.mode === "initial" ? "Finalize new PR" : "Finalize branch update"}.`);
+          setStatus(`Task is ready. Review the task and choose ${taskState.mode === "initial" ? "Finalize new PR" : "Finalize PR update"}.`);
           return;
         }
-        setStatus(`Task is still running. Waiting for ${taskState.mode === "initial" ? "Create PR" : "Update branch"}…`);
+        setStatus(`Task is still running. Waiting for ${taskState.mode === "initial" ? "Create PR" : "provider publication action"}…`);
       } catch (error) {
         setStatus(`Monitoring: ${error.message}. Will retry.`, true);
       }
@@ -288,18 +313,29 @@ async function finishInitialAfterPrCreated() {
 async function finalizeUpdate() {
   requireTaskState("update");
   if (!["running", "ready"].includes(taskState.phase)) throw new Error(`update task cannot finalize from phase ${taskState.phase}`);
+
+  const preAction = await publish("/pr/snapshot", {
+    target_repository: taskState.repository,
+    pull_request: taskState.pull_request,
+  });
+  assertUpdatePreActionSnapshot(preAction);
+
   taskState.phase = "finalizing";
   await saveTaskState();
-  setStatus("Updating the PR branch and verifying the remote head…");
+  setStatus("Publishing the update and verifying the existing PR head…");
 
   try {
     const result = await send({
       type: "crossdock.applyBranchUpdate",
+      targetRepository: taskState.repository,
+      pullRequest: taskState.pull_request,
       captureReport: taskState.evidence_policy.report !== "omit",
     });
     taskState.phase = "branch-update-clicked";
     taskState.final_task_url = result.taskUrl;
     taskState.final_report = result.report;
+    taskState.update_pr_discovery = result.discovery;
+    taskState.provider_action = result.providerAction;
     await saveTaskState();
     await finishUpdateAfterRemoteChange();
   } catch (error) {
@@ -320,6 +356,8 @@ async function finishUpdateAfterRemoteChange() {
     repository: taskState.repository,
     prNumber: taskState.pull_request,
     previousSha: taskState.initial_head_sha,
+    workingBranch: taskState.initial_working_branch,
+    discovery: taskState.update_pr_discovery,
   });
   const stored = await chrome.storage.local.get("parentTaskId");
   const result = { taskUrl: taskState.final_task_url, report: taskState.final_report };
@@ -336,18 +374,69 @@ async function finishUpdateAfterRemoteChange() {
 
   const prNumber = taskState.pull_request;
   await completeTask(prNumber);
-  setStatus(`Branch update recorded on PR #${prNumber} at ${changed.head_sha.slice(0, 12)}.`);
+  setStatus(`PR update recorded on #${prNumber} at ${changed.head_sha.slice(0, 12)}.`);
 }
 
-async function waitForPrHeadChange({ repository, prNumber, previousSha }) {
+function assertUpdatePreActionSnapshot(snapshot) {
+  if (!taskState.initial_working_branch) throw new Error("pre-update PR working branch snapshot is missing");
+  if (!taskState.initial_head_sha) throw new Error("pre-update PR head snapshot is missing");
+  if (taskState.provider_branch !== taskState.initial_working_branch) {
+    throw new Error(`Codex provider branch does not match frozen PR working branch: ${taskState.provider_branch || "none"}`);
+  }
+  if (snapshot.repository !== taskState.repository) throw new Error("existing PR repository changed before provider publication");
+  if (snapshot.working_branch !== taskState.initial_working_branch) throw new Error("existing PR working branch changed before provider publication");
+  if (snapshot.head_sha !== taskState.initial_head_sha) throw new Error("existing PR head changed before provider publication");
+}
+
+async function waitForPrHeadChange({ repository, prNumber, previousSha, workingBranch, discovery }) {
   if (!previousSha) throw new Error("pre-update PR head snapshot is missing");
+  if (!workingBranch) throw new Error("pre-update PR working branch snapshot is missing");
+  if (!discovery) throw new Error("update PR discovery baseline is missing");
+
   const deadline = Date.now() + 120_000;
   while (Date.now() < deadline) {
+    const evidence = await send({
+      type: "crossdock.inspectUpdatePrEvidence",
+      targetRepository: repository,
+      pullRequest: prNumber,
+      discovery,
+    });
+    if (evidence.integrityError) {
+      taskState.phase = "pr-update-integrity-error";
+      taskState.pr_integrity_error = evidence.integrityError;
+      await saveTaskState();
+      throw new Error(evidence.integrityError);
+    }
+
     const snapshot = await publish("/pr/snapshot", { target_repository: repository, pull_request: prNumber });
-    if (snapshot.head_sha && snapshot.head_sha !== previousSha) return snapshot;
+    if (snapshot.repository !== repository || snapshot.working_branch !== workingBranch) {
+      const message = "existing PR repository or working branch changed after provider publication";
+      taskState.phase = "pr-update-integrity-error";
+      taskState.pr_integrity_error = message;
+      await saveTaskState();
+      throw new Error(message);
+    }
+
+    if (snapshot.head_sha && snapshot.head_sha !== previousSha) {
+      const finalEvidence = await send({
+        type: "crossdock.inspectUpdatePrEvidence",
+        targetRepository: repository,
+        pullRequest: prNumber,
+        discovery,
+      });
+      if (finalEvidence.integrityError) {
+        taskState.phase = "pr-update-integrity-error";
+        taskState.pr_integrity_error = finalEvidence.integrityError;
+        await saveTaskState();
+        throw new Error(finalEvidence.integrityError);
+      }
+      return snapshot;
+    }
+
     await sleep(2000);
   }
-  throw new Error("timed out waiting for the GitHub PR head to change after Update branch");
+
+  throw new Error("timed out waiting for the existing GitHub PR head to change after provider publication");
 }
 
 async function completeTask(prNumber) {

--- a/scripts/apply-update-provider-action-semantics.mjs
+++ b/scripts/apply-update-provider-action-semantics.mjs
@@ -1,0 +1,475 @@
+import fs from "node:fs";
+
+const files = {
+  content: "extension/content.js",
+  background: "extension/background.js",
+  dashboard: "extension/dashboard.js",
+  html: "extension/dashboard.html",
+  dashboardTests: "tests/dashboard.test.js",
+  integrityTests: "tests/pr-integrity-ui.test.js",
+};
+
+const read = (path) => fs.readFileSync(path, "utf8");
+const write = (path, value) => fs.writeFileSync(path, value, "utf8");
+
+function replaceOnce(source, oldText, newText, label) {
+  const index = source.indexOf(oldText);
+  if (index < 0) throw new Error(`${label} not found`);
+  if (source.indexOf(oldText, index + oldText.length) >= 0) throw new Error(`${label} is ambiguous`);
+  return source.slice(0, index) + newText + source.slice(index + oldText.length);
+}
+
+function replaceRange(source, startMarker, endMarker, replacement, label) {
+  const start = source.indexOf(startMarker);
+  if (start < 0) throw new Error(`${label} start not found`);
+  const end = source.indexOf(endMarker, start + startMarker.length);
+  if (end < 0) throw new Error(`${label} end not found`);
+  return source.slice(0, start) + replacement + "\n\n" + source.slice(end);
+}
+
+let content = read(files.content);
+let background = read(files.background);
+let dashboard = read(files.dashboard);
+let html = read(files.html);
+let dashboardTests = read(files.dashboardTests);
+let integrityTests = read(files.integrityTests);
+
+content = replaceRange(
+  content,
+  "function inspectCodexTask() {",
+  "function prepareCreatePr(",
+  `function inspectCodexTask() {
+  requireCodexPage();
+  return {
+    taskUrl: location.href,
+    createPrAvailable: Boolean(findButton(["Create PR"], false)),
+    updateBranchAvailable: Boolean(findButton(["Update branch"], false)),
+  };
+}`,
+  "inspectCodexTask",
+);
+
+content = replaceRange(
+  content,
+  "function prepareBranchUpdate(",
+  "function captureCodexReport() {",
+  `function prepareBranchUpdate(captureReport = true) {
+  requireCodexPage();
+
+  const actions = [
+    { providerAction: "update_branch", button: findButton(["Update branch"], false) },
+    { providerAction: "create_pr", button: findButton(["Create PR"], false) },
+  ].filter(({ button }) => Boolean(button));
+
+  if (actions.length !== 1) {
+    throw new Error(\`Codex update publication action must resolve to exactly one supported control; found \${actions.length}\`);
+  }
+
+  const result = { taskUrl: location.href, providerAction: actions[0].providerAction };
+  if (captureReport) result.report = captureCodexReport();
+  actions[0].button.click();
+  return result;
+}`,
+  "prepareBranchUpdate",
+);
+
+background = replaceOnce(
+  background,
+  `    case "crossdock.applyBranchUpdate": {
+      const tab = await findChatGptTab(true);
+      return sendToTab(tab.id, { type: "crossdock.prepareBranchUpdate", captureReport: message.captureReport !== false });
+    }`,
+  `    case "crossdock.applyBranchUpdate": {
+      const tab = await findChatGptTab(true);
+      const discovery = { beforePrUrls: await snapshotPrEvidence(tab.id) };
+      const prepared = await sendToTab(tab.id, {
+        type: "crossdock.prepareBranchUpdate",
+        captureReport: message.captureReport !== false,
+      });
+      return { ...prepared, discovery };
+    }
+    case "crossdock.inspectUpdatePrEvidence": {
+      const tab = await findChatGptTab(true);
+      return inspectUpdatePrEvidence({
+        tabId: tab.id,
+        targetRepository: message.targetRepository,
+        pullRequest: message.pullRequest,
+        discovery: message.discovery,
+      });
+    }`,
+  "background update action",
+);
+
+background = replaceOnce(
+  background,
+  `function wrongRepositoryPrMessage(targetRepository, urls) {
+  const repositories = [...new Set(urls.map(repositoryFromGitHubPrUrl))];
+  return \`created PR integrity failure: expected repository \${targetRepository}, but new PR evidence appeared in \${repositories.join(", ")}: \${urls.join(", ")}\`;
+}`,
+  `function wrongRepositoryPrMessage(targetRepository, urls) {
+  const repositories = [...new Set(urls.map(repositoryFromGitHubPrUrl))];
+  return \`created PR integrity failure: expected repository \${targetRepository}, but new PR evidence appeared in \${repositories.join(", ")}: \${urls.join(", ")}\`;
+}
+
+async function inspectUpdatePrEvidence({ tabId, targetRepository, pullRequest, discovery }) {
+  if (!Number.isInteger(pullRequest) || pullRequest <= 0) {
+    throw new Error("existing pull request must be a positive integer");
+  }
+
+  const evidence = await findNewPrEvidence({ tabId, targetRepository, discovery });
+  if (evidence.wrongRepository.length) {
+    const repositories = [...new Set(evidence.wrongRepository.map(repositoryFromGitHubPrUrl))];
+    return {
+      integrityError: \`update PR integrity failure: expected repository \${targetRepository}, but new PR evidence appeared in \${repositories.join(", ")}: \${evidence.wrongRepository.join(", ")}\`,
+    };
+  }
+
+  const expectedPrUrl = canonicalPrUrl(
+    \`https://github.com/\${targetRepository}/pull/\${pullRequest}\`,
+    targetRepository,
+  );
+  const unexpectedTarget = evidence.target.filter((url) => url !== expectedPrUrl);
+  if (unexpectedTarget.length) {
+    return {
+      integrityError: \`update PR integrity failure: expected existing PR \${expectedPrUrl}, but new target-repository PR evidence appeared: \${unexpectedTarget.join(", ")}\`,
+    };
+  }
+
+  return { integrityError: null };
+}`,
+  "update PR evidence helper",
+);
+
+dashboard = replaceOnce(
+  dashboard,
+  `  const initialSnapshot = mode === "update"
+    ? await publish("/pr/snapshot", { target_repository: repository, pull_request: prNumber }, serviceUrl)
+    : null;
+
+  const pending = {`,
+  `  const initialSnapshot = mode === "update"
+    ? await publish("/pr/snapshot", { target_repository: repository, pull_request: prNumber }, serviceUrl)
+    : null;
+
+  if (initialSnapshot && (
+    initialSnapshot.repository !== repository ||
+    typeof initialSnapshot.working_branch !== "string" ||
+    !initialSnapshot.working_branch.trim() ||
+    typeof initialSnapshot.head_sha !== "string" ||
+    !initialSnapshot.head_sha.trim()
+  )) {
+    throw new Error("existing PR snapshot did not return the configured repository, working branch, and head SHA");
+  }
+
+  const pending = {`,
+  "initial PR snapshot validation",
+);
+
+dashboard = replaceOnce(
+  dashboard,
+  `    initial_head_sha: initialSnapshot?.head_sha ?? null,
+    phase: "submitting",`,
+  `    initial_head_sha: initialSnapshot?.head_sha ?? null,
+    initial_working_branch: initialSnapshot?.working_branch?.trim() ?? null,
+    phase: "submitting",`,
+  "pending update branch snapshot",
+);
+
+dashboard = replaceOnce(
+  dashboard,
+  `  taskState = { ...pending, task_url: result.taskUrl, phase: "running" };
+  await saveTaskState();
+  setStatus(\`Task submitted. Monitoring for \${mode === "initial" ? "Create PR" : "Update branch"} readiness…\`);`,
+  `  taskState = {
+    ...pending,
+    task_url: result.taskUrl,
+    provider_branch: result.providerContext?.base_branch ?? null,
+    phase: "running",
+  };
+  await saveTaskState();
+  setStatus(\`Task submitted. Monitoring for \${mode === "initial" ? "Create PR" : "provider publication"} readiness…\`);`,
+  "submitted task state",
+);
+
+dashboard = replaceOnce(
+  dashboard,
+  `      if (taskState.phase === "pr-create-integrity-error") {
+        setStatus(\`PR creation integrity failure: \${taskState.pr_integrity_error}\`, true);
+        return;
+      }`,
+  `      if (taskState.phase === "pr-create-integrity-error") {
+        setStatus(\`PR creation integrity failure: \${taskState.pr_integrity_error}\`, true);
+        return;
+      }
+
+      if (taskState.phase === "pr-update-integrity-error") {
+        setStatus(\`PR update integrity failure: \${taskState.pr_integrity_error}\`, true);
+        return;
+      }`,
+  "update integrity phase",
+);
+
+dashboard = replaceOnce(
+  dashboard,
+  `        const state = await send({ type: "crossdock.inspectCodex" });
+        const ready = taskState.mode === "initial" ? state.createPrAvailable : state.updateBranchAvailable;
+        if (ready) {`,
+  `        const state = await send({ type: "crossdock.inspectCodex" });
+        const updateActionCount = Number(Boolean(state.updateBranchAvailable)) + Number(Boolean(state.createPrAvailable));
+        if (taskState.mode === "update" && updateActionCount > 1) {
+          throw new Error(\`Codex update publication action is ambiguous; found \${updateActionCount} supported controls\`);
+        }
+        const ready = taskState.mode === "initial" ? state.createPrAvailable : updateActionCount === 1;
+        if (ready) {`,
+  "update readiness",
+);
+
+dashboard = replaceOnce(
+  dashboard,
+  `          setStatus(\`Task is ready. Review the task and choose \${taskState.mode === "initial" ? "Finalize new PR" : "Finalize branch update"}.\`);`,
+  `          setStatus(\`Task is ready. Review the task and choose \${taskState.mode === "initial" ? "Finalize new PR" : "Finalize PR update"}.\`);`,
+  "ready status",
+);
+
+dashboard = replaceOnce(
+  dashboard,
+  `        setStatus(\`Task is still running. Waiting for \${taskState.mode === "initial" ? "Create PR" : "Update branch"}…\`);`,
+  `        setStatus(\`Task is still running. Waiting for \${taskState.mode === "initial" ? "Create PR" : "provider publication action"}…\`);`,
+  "running status",
+);
+
+dashboard = replaceRange(
+  dashboard,
+  "async function finalizeUpdate() {",
+  "async function finishUpdateAfterRemoteChange() {",
+  `async function finalizeUpdate() {
+  requireTaskState("update");
+  if (!["running", "ready"].includes(taskState.phase)) throw new Error(\`update task cannot finalize from phase \${taskState.phase}\`);
+
+  const preAction = await publish("/pr/snapshot", {
+    target_repository: taskState.repository,
+    pull_request: taskState.pull_request,
+  });
+  assertUpdatePreActionSnapshot(preAction);
+
+  taskState.phase = "finalizing";
+  await saveTaskState();
+  setStatus("Publishing the update and verifying the existing PR head…");
+
+  try {
+    const result = await send({
+      type: "crossdock.applyBranchUpdate",
+      targetRepository: taskState.repository,
+      pullRequest: taskState.pull_request,
+      captureReport: taskState.evidence_policy.report !== "omit",
+    });
+    taskState.phase = "branch-update-clicked";
+    taskState.final_task_url = result.taskUrl;
+    taskState.final_report = result.report;
+    taskState.update_pr_discovery = result.discovery;
+    taskState.provider_action = result.providerAction;
+    await saveTaskState();
+    await finishUpdateAfterRemoteChange();
+  } catch (error) {
+    if (taskState?.phase === "finalizing") {
+      taskState.phase = "ready";
+      await saveTaskState();
+    } else if (taskState?.phase === "branch-update-clicked") {
+      void monitorTask();
+    }
+    throw error;
+  }
+}`,
+  "finalizeUpdate",
+);
+
+dashboard = replaceOnce(
+  dashboard,
+  `  const changed = await waitForPrHeadChange({
+    repository: taskState.repository,
+    prNumber: taskState.pull_request,
+    previousSha: taskState.initial_head_sha,
+  });`,
+  `  const changed = await waitForPrHeadChange({
+    repository: taskState.repository,
+    prNumber: taskState.pull_request,
+    previousSha: taskState.initial_head_sha,
+    workingBranch: taskState.initial_working_branch,
+    discovery: taskState.update_pr_discovery,
+  });`,
+  "post-publication PR verification call",
+);
+
+dashboard = replaceOnce(
+  dashboard,
+  `  setStatus(\`Branch update recorded on PR #\${prNumber} at \${changed.head_sha.slice(0, 12)}.\`);`,
+  `  setStatus(\`PR update recorded on #\${prNumber} at \${changed.head_sha.slice(0, 12)}.\`);`,
+  "update completion status",
+);
+
+dashboard = replaceRange(
+  dashboard,
+  "async function waitForPrHeadChange(",
+  "async function completeTask(",
+  `function assertUpdatePreActionSnapshot(snapshot) {
+  if (!taskState.initial_working_branch) throw new Error("pre-update PR working branch snapshot is missing");
+  if (!taskState.initial_head_sha) throw new Error("pre-update PR head snapshot is missing");
+  if (taskState.provider_branch !== taskState.initial_working_branch) {
+    throw new Error(\`Codex provider branch does not match frozen PR working branch: \${taskState.provider_branch || "none"}\`);
+  }
+  if (snapshot.repository !== taskState.repository) throw new Error("existing PR repository changed before provider publication");
+  if (snapshot.working_branch !== taskState.initial_working_branch) throw new Error("existing PR working branch changed before provider publication");
+  if (snapshot.head_sha !== taskState.initial_head_sha) throw new Error("existing PR head changed before provider publication");
+}
+
+async function waitForPrHeadChange({ repository, prNumber, previousSha, workingBranch, discovery }) {
+  if (!previousSha) throw new Error("pre-update PR head snapshot is missing");
+  if (!workingBranch) throw new Error("pre-update PR working branch snapshot is missing");
+  if (!discovery) throw new Error("update PR discovery baseline is missing");
+
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    const evidence = await send({
+      type: "crossdock.inspectUpdatePrEvidence",
+      targetRepository: repository,
+      pullRequest: prNumber,
+      discovery,
+    });
+    if (evidence.integrityError) {
+      taskState.phase = "pr-update-integrity-error";
+      taskState.pr_integrity_error = evidence.integrityError;
+      await saveTaskState();
+      throw new Error(evidence.integrityError);
+    }
+
+    const snapshot = await publish("/pr/snapshot", { target_repository: repository, pull_request: prNumber });
+    if (snapshot.repository !== repository || snapshot.working_branch !== workingBranch) {
+      const message = "existing PR repository or working branch changed after provider publication";
+      taskState.phase = "pr-update-integrity-error";
+      taskState.pr_integrity_error = message;
+      await saveTaskState();
+      throw new Error(message);
+    }
+
+    if (snapshot.head_sha && snapshot.head_sha !== previousSha) {
+      const finalEvidence = await send({
+        type: "crossdock.inspectUpdatePrEvidence",
+        targetRepository: repository,
+        pullRequest: prNumber,
+        discovery,
+      });
+      if (finalEvidence.integrityError) {
+        taskState.phase = "pr-update-integrity-error";
+        taskState.pr_integrity_error = finalEvidence.integrityError;
+        await saveTaskState();
+        throw new Error(finalEvidence.integrityError);
+      }
+      return snapshot;
+    }
+
+    await sleep(2000);
+  }
+
+  throw new Error("timed out waiting for the existing GitHub PR head to change after provider publication");
+}`,
+  "waitForPrHeadChange",
+);
+
+html = replaceOnce(
+  html,
+  '<button id="finalize-update">Finalize branch update</button>',
+  '<button id="finalize-update">Finalize PR update</button>',
+  "finalize update label",
+);
+
+dashboardTests = replaceOnce(
+  dashboardTests,
+  `      initial_head_sha: "old-head",
+      task_url: "https://agent.example/tasks/1",`,
+  `      initial_head_sha: "old-head",
+      initial_working_branch: "feature/update",
+      provider_branch: "feature/update",
+      task_url: "https://agent.example/tasks/1",`,
+  "dashboard test frozen branch",
+);
+
+dashboardTests = replaceOnce(
+  dashboardTests,
+  `        if (message.type === "crossdock.applyBranchUpdate") {
+          return { ok: true, result: { taskUrl: "https://agent.example/tasks/1", report: "Done" } };
+        }
+        return { ok: true, result: {} };`,
+  `        if (message.type === "crossdock.applyBranchUpdate") {
+          return {
+            ok: true,
+            result: {
+              taskUrl: "https://agent.example/tasks/1",
+              report: "Done",
+              providerAction: "create_pr",
+              discovery: { beforePrUrls: [] },
+            },
+          };
+        }
+        if (message.type === "crossdock.inspectUpdatePrEvidence") {
+          return { ok: true, result: { integrityError: null } };
+        }
+        return { ok: true, result: {} };`,
+  "dashboard test provider action",
+);
+
+dashboardTests = replaceOnce(
+  dashboardTests,
+  `  globalThis.fetch = async (url, init) => {
+    fetchCalls.push({ url, init });
+    if (url.endsWith("/pr/snapshot")) return okResponse({ head_sha: "new-head" });
+    if (url.endsWith("/handoff/update")) return okResponse({ task_record_url: "https://records.example/task" });`,
+  `  let prSnapshotCalls = 0;
+  globalThis.fetch = async (url, init) => {
+    fetchCalls.push({ url, init });
+    if (url.endsWith("/pr/snapshot")) {
+      prSnapshotCalls += 1;
+      return okResponse({
+        repository: "example/repo",
+        working_branch: "feature/update",
+        head_sha: prSnapshotCalls === 1 ? "old-head" : "new-head",
+      });
+    }
+    if (url.endsWith("/handoff/update")) return okResponse({ task_record_url: "https://records.example/task" });`,
+  "dashboard test PR snapshots",
+);
+
+if (!integrityTests.includes('test("existing-PR update snapshots PR evidence before provider publication"')) {
+  integrityTests += `\n\ntest("existing-PR update snapshots PR evidence before provider publication", () => {
+  const start = background.indexOf('case "crossdock.applyBranchUpdate"');
+  const end = background.indexOf('case "crossdock.openChatGPT"');
+  const updateCase = background.slice(start, end);
+  assert.match(updateCase, /beforePrUrls: await snapshotPrEvidence/);
+  assert.match(updateCase, /crossdock\\.prepareBranchUpdate/);
+  assert.match(updateCase, /crossdock\\.inspectUpdatePrEvidence/);
+});
+
+test("update PR integrity permits the expected existing PR but rejects another PR", () => {
+  assert.match(background, /expectedPrUrl/);
+  assert.match(background, /unexpectedTarget = evidence\\.target\\.filter/);
+  assert.match(background, /update PR integrity failure/);
+  assert.match(dashboard, /pr-update-integrity-error/);
+});
+
+test("update readiness accepts one provider publication control instead of requiring Update branch", () => {
+  assert.match(dashboard, /updateActionCount/);
+  assert.match(dashboard, /state\\.updateBranchAvailable/);
+  assert.match(dashboard, /state\\.createPrAvailable/);
+  assert.match(dashboard, /updateActionCount === 1/);
+});\n`;
+}
+
+for (const [path, value] of [
+  [files.content, content],
+  [files.background, background],
+  [files.dashboard, dashboard],
+  [files.html, html],
+  [files.dashboardTests, dashboardTests],
+  [files.integrityTests, integrityTests],
+]) write(path, value);
+
+console.log("Applied update provider-action semantics patch.");

--- a/tests/dashboard-recovery.test.js
+++ b/tests/dashboard-recovery.test.js
@@ -106,9 +106,32 @@ test("captured memory-only report stays live for handoff but never enters persis
   globalThis.document = { getElementById: (id) => elements.get(id) ?? null, querySelectorAll: () => [] };
   globalThis.chrome = {
     runtime: { async sendMessage(message) {
-      if (message.type === "crossdock.submitCodex") return { ok: true, result: { taskUrl: "https://agent.example/tasks/2" } };
-      if (message.type === "crossdock.inspectCodex") return { ok: true, result: { updateBranchAvailable: true } };
-      if (message.type === "crossdock.applyBranchUpdate") return { ok: true, result: { taskUrl: "https://agent.example/tasks/2", report: "private report bytes" } };
+      if (message.type === "crossdock.submitCodex") {
+        return {
+          ok: true,
+          result: {
+            taskUrl: "https://agent.example/tasks/2",
+            providerContext: { repository: "example/repo", base_branch: "feature/update" },
+          },
+        };
+      }
+      if (message.type === "crossdock.inspectCodex") {
+        return { ok: true, result: { updateBranchAvailable: true, createPrAvailable: false } };
+      }
+      if (message.type === "crossdock.applyBranchUpdate") {
+        return {
+          ok: true,
+          result: {
+            taskUrl: "https://agent.example/tasks/2",
+            report: "private report bytes",
+            providerAction: "update_branch",
+            discovery: { beforePrUrls: [] },
+          },
+        };
+      }
+      if (message.type === "crossdock.inspectUpdatePrEvidence") {
+        return { ok: true, result: { integrityError: null } };
+      }
       return { ok: true, result: {} };
     } },
     storage: { local: {
@@ -119,7 +142,14 @@ test("captured memory-only report stays live for handoff but never enters persis
   };
   globalThis.fetch = async (url, init) => {
     requests.push({ url, init });
-    if (url.endsWith("/pr/snapshot")) return okResponse({ head_sha: requests.filter((call) => call.url.endsWith("/pr/snapshot")).length === 1 ? "old" : "new" });
+    if (url.endsWith("/pr/snapshot")) {
+      const count = requests.filter((call) => call.url.endsWith("/pr/snapshot")).length;
+      return okResponse({
+        repository: "example/repo",
+        working_branch: "feature/update",
+        head_sha: count <= 2 ? "old" : "new",
+      });
+    }
     if (url.endsWith("/handoff/update")) return okResponse({ task_record_url: "https://records.example/task" });
     throw new Error(`unexpected fetch: ${url}`);
   };

--- a/tests/dashboard.test.js
+++ b/tests/dashboard.test.js
@@ -176,6 +176,8 @@ test("dashboard restoration keeps recovered update requests on frozen endpoint a
       storage: { repository: "example/records", branch: "main" },
       pull_request: 7,
       initial_head_sha: "old-head",
+      initial_working_branch: "feature/update",
+      provider_branch: "feature/update",
       task_url: "https://agent.example/tasks/1",
       phase: "ready",
     },
@@ -191,7 +193,18 @@ test("dashboard restoration keeps recovered update requests on frozen endpoint a
     runtime: {
       async sendMessage(message) {
         if (message.type === "crossdock.applyBranchUpdate") {
-          return { ok: true, result: { taskUrl: "https://agent.example/tasks/1", report: "Done" } };
+          return {
+            ok: true,
+            result: {
+              taskUrl: "https://agent.example/tasks/1",
+              report: "Done",
+              providerAction: "create_pr",
+              discovery: { beforePrUrls: [] },
+            },
+          };
+        }
+        if (message.type === "crossdock.inspectUpdatePrEvidence") {
+          return { ok: true, result: { integrityError: null } };
         }
         return { ok: true, result: {} };
       },
@@ -207,9 +220,17 @@ test("dashboard restoration keeps recovered update requests on frozen endpoint a
       },
     },
   };
+  let prSnapshotCalls = 0;
   globalThis.fetch = async (url, init) => {
     fetchCalls.push({ url, init });
-    if (url.endsWith("/pr/snapshot")) return okResponse({ head_sha: "new-head" });
+    if (url.endsWith("/pr/snapshot")) {
+      prSnapshotCalls += 1;
+      return okResponse({
+        repository: "example/repo",
+        working_branch: "feature/update",
+        head_sha: prSnapshotCalls === 1 ? "old-head" : "new-head",
+      });
+    }
     if (url.endsWith("/handoff/update")) return okResponse({ task_record_url: "https://records.example/task" });
     throw new Error(`unexpected fetch: ${url}`);
   };

--- a/tests/pr-integrity-ui.test.js
+++ b/tests/pr-integrity-ui.test.js
@@ -34,3 +34,27 @@ test("integrity failure is persisted instead of entering uncertain retry", () =>
   assert.ok(uncertainIndex > integrityIndex);
   assert.match(dashboard.slice(integrityIndex, uncertainIndex), /await saveTaskState\(\)/);
 });
+
+
+test("existing-PR update snapshots PR evidence before provider publication", () => {
+  const start = background.indexOf('case "crossdock.applyBranchUpdate"');
+  const end = background.indexOf('case "crossdock.openChatGPT"');
+  const updateCase = background.slice(start, end);
+  assert.match(updateCase, /beforePrUrls: await snapshotPrEvidence/);
+  assert.match(updateCase, /crossdock\.prepareBranchUpdate/);
+  assert.match(updateCase, /crossdock\.inspectUpdatePrEvidence/);
+});
+
+test("update PR integrity permits the expected existing PR but rejects another PR", () => {
+  assert.match(background, /expectedPrUrl/);
+  assert.match(background, /unexpectedTarget = evidence\.target\.filter/);
+  assert.match(background, /update PR integrity failure/);
+  assert.match(dashboard, /pr-update-integrity-error/);
+});
+
+test("update readiness accepts one provider publication control instead of requiring Update branch", () => {
+  assert.match(dashboard, /updateActionCount/);
+  assert.match(dashboard, /state\.updateBranchAvailable/);
+  assert.match(dashboard, /state\.createPrAvailable/);
+  assert.match(dashboard, /updateActionCount === 1/);
+});


### PR DESCRIPTION
Fixes #157.

Authenticated live testing showed that Codex can expose `Create PR` on a completed task that is already based on the exact working branch of an existing pull request. Crossdock previously treated `Update branch` as the update-mode readiness contract and therefore stalled.

This change treats provider action labels as UI vocabulary while GitHub state remains authoritative:
- freezes the existing PR repository, working branch, and head SHA;
- accepts exactly one supported provider publication action (`Update branch` or `Create PR`);
- revalidates the existing PR immediately before provider mutation;
- snapshots PR evidence before invoking the provider action;
- verifies the same PR/working branch remains and its head SHA advances;
- treats unexpected new PR evidence as a terminal integrity failure;
- preserves update provenance behavior without rewriting the original PR body.

Local validation:
- `npm test`: 214/214 passing
- `npm run check`: passing
- `git diff --check`: passing