### PR TITLE
Define provider-task continuation architecture and live-test checklist

### DIFF
--- a/docs/architecture/provider-task-continuation.md
+++ b/docs/architecture/provider-task-continuation.md
@@ -1,0 +1,132 @@
+# Provider-task continuation for existing-PR updates
+
+## Purpose
+
+Crossdock treats a coding-provider task/conversation and a GitHub pull request as related but distinct identities. Authenticated Codex testing established that an existing PR is updated by continuing the exact provider task that originated it, not by creating a fresh provider task from the PR branch.
+
+This document defines the provider-neutral architecture consequence while recording the current Codex adapter behavior as an implementation example.
+
+## Work-item identity model
+
+An existing-PR update spans four identities:
+
+1. **Crossdock work item** — the user-visible repository/PR operation and immutable Crossdock task record.
+2. **GitHub PR identity** — exact target repository plus pull-request number.
+3. **GitHub working state** — current PR working branch and head SHA, read live from GitHub.
+4. **Provider task identity** — the exact coding-provider task/conversation that originated the PR.
+
+No one identity substitutes for another.
+
+In particular:
+
+- a matching repository/branch does not prove that a fresh provider task is the originating task;
+- whichever provider task page happens to be open is not authoritative;
+- a provider task's displayed branch label is not authoritative for GitHub PR working state;
+- a PR-visible provenance link is optional presentation, not the durable routing authority.
+
+## Authenticated Codex evidence
+
+The current Codex Cloud browser UI demonstrated this lifecycle:
+
+```text
+new task
+  -> Create PR
+  -> PR exists
+  -> follow-up in the same task
+  -> Update branch
+  -> same PR head advances
+```
+
+A fresh task created from the existing PR's working branch instead produced a new child PR. Crossdock's integrity guard correctly rejected that outcome, but the experiment showed that `fresh task from branch` and `continue originating task` are semantically different operations.
+
+The same task also temporarily displayed `main` after a follow-up completed even though GitHub's existing PR still used its `codex/...` working branch. Crossdock therefore must keep GitHub branch/head identity separate from provider UI labels.
+
+See `docs/testing/live-test-log-2026-09-05.md`.
+
+## Normal existing-PR update flow
+
+For an existing PR, the normal workflow is:
+
+1. Resolve the exact originating provider task from durable Crossdock-owned provenance.
+2. Read the current GitHub PR snapshot and freeze:
+   - repository;
+   - PR number;
+   - working branch;
+   - pre-update head SHA.
+3. Navigate the controlled provider tab to the exact provider task.
+4. Verify the provider task identity before mutation.
+5. Submit the captured handoff prompt through the provider task's continuation/follow-up input.
+6. Prove that the provider accepted the follow-up; do not enter `running` merely because text was written or a button was clicked.
+7. Monitor the same provider task identity until provider-native update publication is available.
+8. Capture the continuation result/report evidence before provider publication.
+9. Re-read the GitHub PR immediately before publication and require the frozen repository, PR number, working branch, and pre-update head SHA to remain unchanged.
+10. Invoke the provider's update publication action exactly once.
+11. Poll GitHub without re-invoking the provider action.
+12. Succeed only when the same PR/working branch remains and the head SHA advances.
+13. Persist a new immutable Crossdock update task record and configured update provenance.
+
+## Provider-task origin binding
+
+The originating provider task must be recoverable from the work-item identity without relying on browser history or PR-visible presentation.
+
+Crossdock's existing immutable task record already carries `agent_task_url`. For deterministic lookup by `{repository, pull_request}`, Crossdock should maintain an immutable origin binding in the configured task-record store. See #163.
+
+The origin binding is routing/provenance metadata, not evidence content. It should not duplicate prompt/report plaintext.
+
+A browser-local cache may accelerate lookup, but the cache is not durable authority.
+
+## Continuation state
+
+A continuation update should retain at least:
+
+- Crossdock task id for the new update instruction;
+- parent Crossdock task id where applicable;
+- target repository;
+- PR number;
+- frozen GitHub working branch;
+- frozen pre-update head SHA;
+- exact provider task URL/identity;
+- evidence/recovery/publication policy;
+- continuation submission status;
+- provider publication-invoked status;
+- PR-discovery baseline for integrity checks.
+
+The update task record should point to the same provider task URL used by the continuation. Reusing the provider task does not mean reusing the Crossdock task record: each Crossdock instruction remains a separate immutable record.
+
+## Failure semantics
+
+Fail closed before provider mutation when:
+
+- the origin binding is missing, malformed, ambiguous, or conflicting;
+- the exact provider task cannot be opened or verified;
+- the provider task no longer accepts continuation;
+- GitHub repository/PR/branch/head identity cannot be frozen exactly.
+
+Fail closed after continuation submission when:
+
+- provider readiness is ambiguous;
+- the provider exposes only a new-PR action where normal update mode requires an update-existing-branch action;
+- the frozen GitHub PR state changes before publication;
+- a newly visible unexpected PR appears;
+- the repository or working branch changes after provider publication;
+- the provider publication action was invoked but the resulting GitHub state cannot be reconciled safely.
+
+After the provider publication action has been invoked, retries may poll/inspect state but must never invoke the publication action again automatically.
+
+## Codex adapter consequence
+
+For the current Codex UI, normal update readiness is **Update branch** after a follow-up in the originating task.
+
+`Create PR` in a fresh task is not an interchangeable update action. If it appears in normal update mode, Crossdock should not treat it as successful update readiness.
+
+The adapter should navigate directly to the exact known `/codex/cloud/tasks/<task-id>` URL, wait for the follow-up composer to be semantically ready, submit once, prove acceptance, and continue monitoring that same task URL.
+
+## Distinct explicit workflow: child task/PR
+
+Crossdock may later support an explicit workflow where a user intentionally creates a fresh provider task from another branch, obtains a child PR, and deliberately integrates that work into another work item.
+
+That is a separate operation. It must not be an automatic fallback for normal existing-PR update mode.
+
+## Public handoff boundary
+
+None of this changes the conversational producer contract. The producer still emits only the minimal handoff payload boundary. Provider task selection, continuation, GitHub identity verification, provenance, and recovery remain Crossdock-owned responsibilities.

--- a/docs/testing/continuation-live-test-checklist.md
+++ b/docs/testing/continuation-live-test-checklist.md
@@ -1,0 +1,124 @@
+# Existing-PR continuation live-test checklist
+
+Use this checklist for the next authenticated browser validation of Crossdock's Codex continuation path. It is intentionally fail-closed and should be followed without manual rescue.
+
+## Preconditions
+
+- Crossdock extension is loaded from the current merged `main` build under test.
+- Loopback service is running on the configured local service URL.
+- GitHub credentials are valid for the disposable target and task-record repositories.
+- Exactly one controlled Codex tab is open under current browser assumptions.
+- ChatGPT, Codex, and GitHub sessions are authenticated.
+- The disposable target PR is open.
+- The target PR has a durable Crossdock origin binding that resolves to exactly one originating Codex task.
+- The next requested change is harmless, easily verified, and changes only the disposable fixture.
+
+If any prerequisite is missing or ambiguous, stop before creating or continuing a provider task.
+
+## Capture and update-mode resolution
+
+1. Configure the target repository and existing PR number in the Crossdock dashboard.
+2. Capture a fresh handoff prompt from ChatGPT.
+3. Confirm Crossdock captured only the inner handoff payload.
+4. Click the Crossdock action that starts the update workflow once.
+5. Confirm Crossdock snapshots the existing GitHub PR and freezes:
+   - repository;
+   - PR number;
+   - working branch;
+   - head SHA.
+6. Confirm Crossdock resolves the exact originating provider task from durable provenance.
+
+Expected: Crossdock does **not** navigate to the generic Codex new-task composer for normal update mode.
+
+## Continuation submission
+
+7. Crossdock navigates its controlled Codex tab to the exact originating task URL.
+8. Crossdock verifies the concrete task identity before writing any prompt.
+9. Crossdock locates the follow-up composer semantically.
+10. Crossdock writes the captured prompt and submits exactly once.
+11. Crossdock proves Codex accepted the follow-up before entering `running`.
+
+Stop and preserve evidence if:
+
+- the task URL differs from the resolved originating task;
+- the follow-up composer is absent or ambiguous;
+- submission is not provably accepted;
+- Crossdock creates a fresh Codex task instead.
+
+## Running/ready state
+
+12. Crossdock monitors the same exact task URL.
+13. The user may review Codex progress; Crossdock should eventually support navigating to Logs as a non-blocking UX enhancement (#159).
+14. On completion, verify the Codex diff/result is exactly the requested change.
+15. Normal update readiness requires **Update branch**.
+
+Stop if normal update mode instead exposes only **Create PR**. Do not click it and do not reinterpret it as update success.
+
+## Review-before-handoff checkpoint
+
+16. With handoff mode set to review, Crossdock should enter `ready` and present **Finalize PR update** (or the current equivalent Crossdock-owned action).
+17. Independently verify GitHub before publication:
+   - same PR remains open;
+   - same working branch;
+   - head SHA still equals the frozen pre-update SHA;
+   - no unintended new PR exists.
+18. Do not click Codex publication controls directly during the Crossdock E2E test.
+
+## Publication
+
+19. Click Crossdock's update-finalization action exactly once.
+20. Crossdock captures the continuation report/result evidence before provider mutation.
+21. Crossdock revalidates the frozen GitHub PR identity and pre-update head.
+22. Crossdock invokes Codex **Update branch** exactly once.
+23. Crossdock polls GitHub without retrying the provider action.
+
+Expected success:
+
+- same target repository;
+- same PR number;
+- same working branch;
+- head SHA changes from the frozen pre-update value;
+- no new PR is created;
+- intended change appears on the existing PR;
+- immutable update task record is created;
+- update record points to the same originating Codex task URL;
+- update record has the expected Crossdock parent linkage;
+- configured update provenance comment is added when enabled;
+- original initial PR body is not rewritten for update provenance;
+- prompt/report evidence follows configured full/hash/omit policy;
+- no secrets appear in public or task-record surfaces.
+
+## Terminal integrity failures
+
+Stop immediately and preserve state if Crossdock reports any integrity error, including:
+
+- unexpected new PR;
+- wrong repository;
+- working-branch mismatch;
+- stale/changed pre-publication head;
+- provider-task identity mismatch;
+- ambiguous provider publication controls;
+- publication invoked but existing PR cannot be reconciled safely.
+
+Do not manually merge/cherry-pick a child PR, re-run provider publication, move branches, rewrite provenance, or clear the active task until evidence is documented.
+
+## Evidence to record
+
+For each authenticated run, record:
+
+- Crossdock commit/build SHA;
+- browser/extension reload state;
+- target repository and PR;
+- frozen pre-update working branch/head SHA;
+- originating provider task URL;
+- submitted continuation prompt (or digest, according to evidence policy);
+- provider ready action shown;
+- result/report summary;
+- provider publication action invoked;
+- post-publication PR branch/head SHA;
+- whether any new PR appeared;
+- task-record URL/version;
+- provenance-comment URL/id when enabled;
+- exact failure text and phase for any stopped run.
+
+Authenticated compatibility evidence must remain separate from independent public handoff-discoverability claims.


### PR DESCRIPTION
Adds architecture and authenticated-test guidance for the existing-PR continuation workflow validated on 2026-09-05.

Documents:
- separate identities for Crossdock work item, GitHub PR state, and provider task;
- normal existing-PR flow as continuation of the exact originating task;
- fail-closed origin binding and publication semantics;
- why Codex task-header branch labels are not authoritative;
- why `Create PR` from a fresh task is not a normal update action;
- a concrete next-session live-test checklist.

Supports #153, #161, and #163. Documentation only.