### PR TITLE
Add immutable PR origin-binding core model

### DIFF
--- a/src/origin-binding.js
+++ b/src/origin-binding.js
@@ -1,0 +1,85 @@
+export const ORIGIN_BINDING_SCHEMA = "crossdock.origin-binding/v1";
+
+export function normalizeOriginRepository(value) {
+  if (typeof value !== "string") throw new TypeError("target_repository must be a string");
+  const repository = value.trim();
+  if (!/^[^/\s]+\/[^/\s]+$/.test(repository)) throw new Error("target_repository must be owner/repo");
+  return repository;
+}
+
+export function normalizePullRequestNumber(value) {
+  if (!Number.isInteger(value) || value <= 0) throw new Error("pull_request must be a positive integer");
+  return value;
+}
+
+export function normalizeOriginTaskUrl(value) {
+  if (typeof value !== "string" || !value.trim()) throw new Error("agent_task_url is required");
+  let url;
+  try {
+    url = new URL(value.trim());
+  } catch {
+    throw new Error("agent_task_url must be an absolute URL");
+  }
+  if (!/^https?:$/.test(url.protocol)) throw new Error("agent_task_url must use http or https");
+  url.hash = "";
+  return url.toString();
+}
+
+function requireString(binding, field) {
+  if (typeof binding[field] !== "string" || !binding[field].trim()) throw new Error(`${field} is required`);
+  return binding[field].trim();
+}
+
+function normalizeTimestamp(value, field) {
+  if (typeof value !== "string" || !value.trim() || Number.isNaN(Date.parse(value))) {
+    throw new Error(`${field} must be an RFC 3339 timestamp`);
+  }
+  return new Date(value).toISOString();
+}
+
+export function validateOriginBinding(binding) {
+  if (!binding || typeof binding !== "object" || Array.isArray(binding)) throw new TypeError("origin binding is required");
+
+  const schema = binding.schema ?? ORIGIN_BINDING_SCHEMA;
+  if (schema !== ORIGIN_BINDING_SCHEMA) throw new Error(`unsupported origin binding schema: ${schema}`);
+
+  const targetRepository = normalizeOriginRepository(binding.target_repository);
+  const pullRequest = normalizePullRequestNumber(binding.pull_request);
+  const taskId = requireString(binding, "originating_task_id");
+  if (!/^[A-Za-z0-9._-]+$/.test(taskId)) throw new Error("originating_task_id may contain only letters, numbers, dot, underscore, and hyphen");
+  const provider = requireString(binding, "provider");
+  if (!/^[A-Za-z0-9._-]+$/.test(provider)) throw new Error("provider may contain only letters, numbers, dot, underscore, and hyphen");
+  const taskUrl = normalizeOriginTaskUrl(binding.agent_task_url);
+  const createdAt = normalizeTimestamp(binding.created_at, "created_at");
+
+  for (const forbidden of ["prompt", "report", "prompt_sha256", "report_sha256"]) {
+    if (Object.hasOwn(binding, forbidden)) throw new Error(`origin binding must not contain ${forbidden}`);
+  }
+
+  const normalized = {
+    schema: ORIGIN_BINDING_SCHEMA,
+    target_repository: targetRepository,
+    pull_request: pullRequest,
+    originating_task_id: taskId,
+    provider,
+    agent_task_url: taskUrl,
+    created_at: createdAt,
+  };
+
+  if (binding.initial_working_branch != null) {
+    normalized.initial_working_branch = requireString(binding, "initial_working_branch");
+  }
+
+  return Object.freeze(normalized);
+}
+
+export function originBindingPath(binding) {
+  const normalized = validateOriginBinding(binding);
+  const [owner, repository] = normalized.target_repository.split("/");
+  return `crossdock/origins/${owner}/${repository}/pull/${normalized.pull_request}.json`;
+}
+
+export function renderOriginBinding(binding) {
+  const normalized = validateOriginBinding(binding);
+  return `${JSON.stringify(normalized, null, 2)}\n`;
+}

--- a/tests/origin-binding.test.js
+++ b/tests/origin-binding.test.js
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  ORIGIN_BINDING_SCHEMA,
+  normalizeOriginRepository,
+  normalizeOriginTaskUrl,
+  normalizePullRequestNumber,
+  originBindingPath,
+  renderOriginBinding,
+  validateOriginBinding,
+} from "../src/origin-binding.js";
+
+const binding = {
+  target_repository: "owner/repo",
+  pull_request: 17,
+  originating_task_id: "crossdock-1234",
+  provider: "codex",
+  agent_task_url: "https://chatgpt.com/codex/cloud/tasks/task_abc",
+  created_at: "2026-09-05T17:00:00Z",
+  initial_working_branch: "codex/example",
+};
+
+test("origin binding validates and freezes canonical routing identity", () => {
+  const normalized = validateOriginBinding(binding);
+  assert.deepEqual(normalized, {
+    schema: ORIGIN_BINDING_SCHEMA,
+    target_repository: "owner/repo",
+    pull_request: 17,
+    originating_task_id: "crossdock-1234",
+    provider: "codex",
+    agent_task_url: "https://chatgpt.com/codex/cloud/tasks/task_abc",
+    created_at: "2026-09-05T17:00:00.000Z",
+    initial_working_branch: "codex/example",
+  });
+  assert.ok(Object.isFrozen(normalized));
+});
+
+test("origin binding path is deterministic from repository and PR identity", () => {
+  assert.equal(originBindingPath(binding), "crossdock/origins/owner/repo/pull/17.json");
+});
+
+test("origin binding rendering is deterministic JSON with a trailing newline", () => {
+  const first = renderOriginBinding(binding);
+  const second = renderOriginBinding({ ...binding });
+  assert.equal(first, second);
+  assert.equal(first.endsWith("\n"), true);
+  assert.deepEqual(JSON.parse(first), validateOriginBinding(binding));
+});
+
+test("origin binding excludes prompt and report evidence", () => {
+  for (const [field, value] of [["prompt", "private"], ["report", "private"], ["prompt_sha256", "abc"], ["report_sha256", "def"]]) {
+    assert.throws(() => validateOriginBinding({ ...binding, [field]: value }), new RegExp(`must not contain ${field}`));
+  }
+});
+
+test("repository and pull request identity fail closed", () => {
+  assert.equal(normalizeOriginRepository(" owner/repo "), "owner/repo");
+  assert.equal(normalizePullRequestNumber(1), 1);
+  for (const value of ["repo", "owner/repo/extra", "owner /repo", ""]) {
+    assert.throws(() => normalizeOriginRepository(value));
+  }
+  for (const value of [0, -1, 1.5, "1", null]) {
+    assert.throws(() => normalizePullRequestNumber(value));
+  }
+});
+
+test("task URL must be absolute http or https and strips fragments", () => {
+  assert.equal(
+    normalizeOriginTaskUrl("https://chatgpt.com/codex/cloud/tasks/task_abc#report"),
+    "https://chatgpt.com/codex/cloud/tasks/task_abc",
+  );
+  for (const value of ["/relative", "javascript:alert(1)", "", null]) {
+    assert.throws(() => normalizeOriginTaskUrl(value));
+  }
+});
+
+test("schema, task id, provider, and timestamp validation fail closed", () => {
+  assert.throws(() => validateOriginBinding({ ...binding, schema: "crossdock.origin-binding/v0" }), /unsupported origin binding schema/);
+  assert.throws(() => validateOriginBinding({ ...binding, originating_task_id: "bad id" }), /originating_task_id/);
+  assert.throws(() => validateOriginBinding({ ...binding, provider: "bad provider" }), /provider/);
+  assert.throws(() => validateOriginBinding({ ...binding, created_at: "not-a-date" }), /created_at/);
+});


### PR DESCRIPTION
Adds the pure validation/rendering model for durable PR-to-originating-provider-task bindings from #163.

Includes:
- `crossdock.origin-binding/v1` schema constant;
- exact owner/repo and positive PR identity validation;
- provider/task-id/task-URL/timestamp validation;
- deterministic `crossdock/origins/<owner>/<repo>/pull/<number>.json` path;
- deterministic JSON rendering;
- explicit rejection of prompt/report evidence fields;
- focused node:test coverage.

This PR intentionally does not yet wire storage/service/browser behavior. It establishes the fail-closed core model first so the later integration in #153/#163 can reuse one canonical validator.