### PR TITLE
Add origin-binding persistence and lookup helpers

### DIFF
--- a/src/origin-binding-storage.js
+++ b/src/origin-binding-storage.js
@@ -1,0 +1,71 @@
+import { originBindingPath, renderOriginBinding, validateOriginBinding } from "./origin-binding.js";
+import { resolveTaskRecordStorage } from "./storage.js";
+
+export async function persistOriginBinding({ github, storage, binding }) {
+  const destination = resolveTaskRecordStorage({ github, storage });
+  const normalized = validateOriginBinding(binding);
+  const path = originBindingPath(normalized);
+  const content = renderOriginBinding(normalized);
+  const input = {
+    path,
+    content,
+    message: `crossdock: bind PR #${normalized.pull_request} to originating task`,
+  };
+
+  if (typeof destination.preflightImmutable === "function") destination.preflightImmutable(input);
+  const persisted = await destination.persistImmutable(input);
+  if (!persisted || typeof persisted !== "object") throw new Error("origin-binding storage returned no persistence result");
+  if (persisted.path !== path || persisted.content !== content) throw new Error("origin-binding storage returned inconsistent persistence metadata");
+  if (typeof persisted.version !== "string" || !persisted.version) throw new Error("origin-binding storage returned no immutable version");
+  if (typeof persisted.url !== "string" || !persisted.url) throw new Error("origin-binding storage returned no durable URL");
+
+  await destination.verifyImmutable({
+    path: persisted.path,
+    version: persisted.version,
+    expectedContent: content,
+  });
+  return { binding: normalized, ...persisted };
+}
+
+export async function resolveOriginBinding({ github, storage, targetRepository, pullRequest }) {
+  const destination = resolveTaskRecordStorage({ github, storage });
+  const path = originBindingLookupPath(targetRepository, pullRequest);
+  const file = await github.getFile(destination.repository, path, destination.branch);
+  const content = decodeGitHubTextFile(file, "origin-binding lookup");
+
+  let parsed;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    throw new Error("origin-binding lookup failed: remote content is not valid JSON");
+  }
+
+  const binding = validateOriginBinding(parsed);
+  if (binding.target_repository !== targetRepository.trim() || binding.pull_request !== pullRequest) {
+    throw new Error("origin-binding lookup failed: remote binding identity does not match requested PR");
+  }
+
+  return Object.freeze({
+    binding,
+    path,
+    storage_repository: destination.repository,
+    storage_branch: destination.branch,
+  });
+}
+
+export function originBindingLookupPath(targetRepository, pullRequest) {
+  const probe = validateOriginBinding({
+    target_repository: targetRepository,
+    pull_request: pullRequest,
+    originating_task_id: "lookup",
+    provider: "lookup",
+    agent_task_url: "https://invalid.example/lookup",
+    created_at: "1970-01-01T00:00:00Z",
+  });
+  return originBindingPath(probe);
+}
+
+function decodeGitHubTextFile(file, context) {
+  if (!file?.sha || typeof file.content !== "string") throw new Error(`${context} failed: remote file missing content`);
+  return Buffer.from(file.content.replace(/\n/g, ""), "base64").toString("utf8");
+}

--- a/tests/origin-binding-storage.test.js
+++ b/tests/origin-binding-storage.test.js
@@ -1,0 +1,133 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  originBindingLookupPath,
+  persistOriginBinding,
+  resolveOriginBinding,
+} from "../src/origin-binding-storage.js";
+
+const binding = {
+  target_repository: "owner/repo",
+  pull_request: 9,
+  originating_task_id: "crossdock-origin",
+  provider: "codex",
+  agent_task_url: "https://chatgpt.com/codex/cloud/tasks/task_origin",
+  created_at: "2026-09-05T17:00:00Z",
+  initial_working_branch: "codex/example",
+};
+
+function encode(content) {
+  return Buffer.from(content, "utf8").toString("base64");
+}
+
+function createStorageMock() {
+  const files = new Map();
+  let writes = 0;
+  const github = {
+    async createFile(repository, path, content, _message, branch) {
+      const key = `${repository}:${branch}:${path}`;
+      if (files.has(key)) {
+        const error = new Error("exists");
+        error.status = 422;
+        throw error;
+      }
+      files.set(key, content);
+      writes += 1;
+      return { commit: { sha: `commit-${writes}` } };
+    },
+    async getFile(repository, path, ref) {
+      const branchKey = `${repository}:${ref}:${path}`;
+      const exact = files.get(branchKey);
+      if (exact != null) return { sha: "blob", content: encode(exact) };
+
+      for (const [key, content] of files) {
+        if (key.endsWith(`:${path}`)) return { sha: "blob", content: encode(content) };
+      }
+      const error = new Error("missing");
+      error.status = 404;
+      throw error;
+    },
+    async getLatestCommitForPath() {
+      return { sha: `commit-${writes || 1}` };
+    },
+  };
+  return { github, files, writes: () => writes };
+}
+
+const storage = { repository: "owner/private-records", branch: "main" };
+
+test("origin binding lookup path depends only on repository and PR identity", () => {
+  assert.equal(originBindingLookupPath("owner/repo", 9), "crossdock/origins/owner/repo/pull/9.json");
+});
+
+test("origin binding persistence writes and verifies one immutable record", async () => {
+  const mock = createStorageMock();
+  const result = await persistOriginBinding({ github: mock.github, storage, binding });
+
+  assert.equal(mock.writes(), 1);
+  assert.equal(result.path, "crossdock/origins/owner/repo/pull/9.json");
+  assert.equal(result.binding.agent_task_url, binding.agent_task_url);
+  assert.match(result.url, /owner\/private-records\/blob\/commit-1\/crossdock\/origins\/owner\/repo\/pull\/9\.json$/);
+});
+
+test("identical origin binding retry is idempotent", async () => {
+  const mock = createStorageMock();
+  const first = await persistOriginBinding({ github: mock.github, storage, binding });
+  const second = await persistOriginBinding({ github: mock.github, storage, binding: { ...binding } });
+
+  assert.equal(mock.writes(), 1);
+  assert.equal(second.content, first.content);
+  assert.equal(second.path, first.path);
+});
+
+test("conflicting origin binding retry fails closed", async () => {
+  const mock = createStorageMock();
+  await persistOriginBinding({ github: mock.github, storage, binding });
+
+  await assert.rejects(
+    persistOriginBinding({
+      github: mock.github,
+      storage,
+      binding: { ...binding, agent_task_url: "https://chatgpt.com/codex/cloud/tasks/task_other" },
+    }),
+    /existing immutable record has different content/,
+  );
+});
+
+test("origin binding resolves by repository and PR without PR-visible provenance", async () => {
+  const mock = createStorageMock();
+  await persistOriginBinding({ github: mock.github, storage, binding });
+
+  const resolved = await resolveOriginBinding({
+    github: mock.github,
+    storage,
+    targetRepository: "owner/repo",
+    pullRequest: 9,
+  });
+
+  assert.equal(resolved.binding.originating_task_id, "crossdock-origin");
+  assert.equal(resolved.binding.agent_task_url, binding.agent_task_url);
+  assert.equal(resolved.storage_repository, "owner/private-records");
+  assert.equal(resolved.storage_branch, "main");
+  assert.ok(Object.isFrozen(resolved));
+});
+
+test("malformed or mismatched remote origin binding fails closed", async () => {
+  const malformed = createStorageMock();
+  const path = originBindingLookupPath("owner/repo", 9);
+  malformed.files.set(`owner/private-records:main:${path}`, "not json\n");
+  await assert.rejects(
+    resolveOriginBinding({ github: malformed.github, storage, targetRepository: "owner/repo", pullRequest: 9 }),
+    /not valid JSON/,
+  );
+
+  const mismatch = createStorageMock();
+  await persistOriginBinding({ github: mismatch.github, storage, binding: { ...binding, target_repository: "owner/other" } });
+  const otherPath = originBindingLookupPath("owner/repo", 9);
+  const stored = [...mismatch.files.values()][0];
+  mismatch.files.set(`owner/private-records:main:${otherPath}`, stored);
+  await assert.rejects(
+    resolveOriginBinding({ github: mismatch.github, storage, targetRepository: "owner/repo", pullRequest: 9 }),
+    /identity does not match requested PR/,
+  );
+});


### PR DESCRIPTION
Builds on #163 and the merged origin-binding core model by adding task-record-store persistence/lookup helpers.

Adds:
- immutable origin-binding persistence through the existing task-record storage adapter;
- remote verification after persistence;
- deterministic lookup by `{target_repository, pull_request}` without PR-visible provenance;
- parsing/identity validation on read;
- tests for write/verify, idempotent retry, conflicting retry, lookup, malformed content, and mismatched identity.

This remains service-layer foundation only; it does not yet wire initial handoff creation or browser continuation routing.