### PR TITLE
Expose origin-binding resolution through the service

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -1,4 +1,5 @@
 import { publishExistingInitialHandoff, publishUpdateHandoff } from "./handoff.js";
+import { resolveOriginBinding } from "./origin-binding-storage.js";
 
 export async function dispatchHandoff({ method, path, body, github }) {
   if (method === "GET" && path === "/health") return { status: 200, body: { ok: true } };
@@ -19,6 +20,32 @@ export async function dispatchHandoff({ method, path, body, github }) {
       pull_request: body.pull_request,
     });
     return { status: 200, body: { repository: task.target_repository, pull_request: task.pull_request, base_branch: task.base_branch, working_branch: task.working_branch, head_sha: task.result_commit } };
+  }
+
+  if (path === "/origin-binding/resolve") {
+    requireObject(body, "body");
+    requireObject(body.storage, "storage");
+    const repository = requireRepository(body.target_repository);
+    const pullRequest = requirePullRequest(body.pull_request);
+    const resolved = await resolveOriginBinding({
+      github,
+      storage: body.storage,
+      targetRepository: repository,
+      pullRequest,
+    });
+    const binding = resolved.binding;
+    return {
+      status: 200,
+      body: {
+        repository: binding.target_repository,
+        pull_request: binding.pull_request,
+        originating_task_id: binding.originating_task_id,
+        provider: binding.provider,
+        agent_task_url: binding.agent_task_url,
+        created_at: binding.created_at,
+        initial_working_branch: binding.initial_working_branch ?? null,
+      },
+    };
   }
 
   if (path === "/handoff/initial" || path === "/handoff/update") {
@@ -68,6 +95,11 @@ function summarizeUpdate(result) {
 function requireRepository(value) {
   if (typeof value !== "string" || !/^[^/\s]+\/[^/\s]+$/.test(value.trim())) throw new Error("target_repository is required in owner/repo form");
   return value.trim();
+}
+
+function requirePullRequest(value) {
+  if (!Number.isInteger(value) || value <= 0) throw new Error("pull_request is required");
+  return value;
 }
 
 function requireObject(value, label) {

--- a/tests/origin-binding-service.test.js
+++ b/tests/origin-binding-service.test.js
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { dispatchHandoff } from "../src/service.js";
+import { renderOriginBinding } from "../src/origin-binding.js";
+
+const storage = { repository: "owner/private-records", branch: "main" };
+const binding = {
+  target_repository: "owner/repo",
+  pull_request: 9,
+  originating_task_id: "crossdock-origin",
+  provider: "codex",
+  agent_task_url: "https://chatgpt.com/codex/cloud/tasks/task_origin",
+  created_at: "2026-09-05T17:00:00Z",
+  initial_working_branch: "codex/example",
+};
+
+function githubWithBinding(value = binding) {
+  const content = renderOriginBinding(value);
+  return {
+    async createFile() { throw new Error("not expected"); },
+    async getFile(repository, path, ref) {
+      assert.equal(repository, "owner/private-records");
+      assert.equal(path, "crossdock/origins/owner/repo/pull/9.json");
+      assert.equal(ref, "main");
+      return { sha: "blob", content: Buffer.from(content, "utf8").toString("base64") };
+    },
+  };
+}
+
+test("origin binding resolution endpoint returns provider task identity", async () => {
+  const result = await dispatchHandoff({
+    method: "POST",
+    path: "/origin-binding/resolve",
+    github: githubWithBinding(),
+    body: { target_repository: " owner/repo ", pull_request: 9, storage },
+  });
+
+  assert.equal(result.status, 200);
+  assert.deepEqual(result.body, {
+    repository: "owner/repo",
+    pull_request: 9,
+    originating_task_id: "crossdock-origin",
+    provider: "codex",
+    agent_task_url: "https://chatgpt.com/codex/cloud/tasks/task_origin",
+    created_at: "2026-09-05T17:00:00.000Z",
+    initial_working_branch: "codex/example",
+  });
+});
+
+test("origin binding resolution endpoint requires explicit storage and positive PR", async () => {
+  await assert.rejects(
+    dispatchHandoff({
+      method: "POST",
+      path: "/origin-binding/resolve",
+      github: githubWithBinding(),
+      body: { target_repository: "owner/repo", pull_request: 9 },
+    }),
+    /storage must be an object/,
+  );
+
+  await assert.rejects(
+    dispatchHandoff({
+      method: "POST",
+      path: "/origin-binding/resolve",
+      github: githubWithBinding(),
+      body: { target_repository: "owner/repo", pull_request: 0, storage },
+    }),
+    /pull_request is required/,
+  );
+});
+
+test("origin binding resolution fails closed when remote identity conflicts", async () => {
+  const conflicting = { ...binding, target_repository: "owner/other" };
+  const content = renderOriginBinding(conflicting);
+  const github = {
+    async createFile() { throw new Error("not expected"); },
+    async getFile() {
+      return { sha: "blob", content: Buffer.from(content, "utf8").toString("base64") };
+    },
+  };
+
+  await assert.rejects(
+    dispatchHandoff({
+      method: "POST",
+      path: "/origin-binding/resolve",
+      github,
+      body: { target_repository: "owner/repo", pull_request: 9, storage },
+    }),
+    /identity does not match requested PR/,
+  );
+});


### PR DESCRIPTION
Adds a narrow service endpoint for resolving the durable PR-to-originating-task binding from #163.

`POST /origin-binding/resolve` now requires explicit task-record storage plus exact repository/PR identity and returns only routing/provenance metadata needed by the browser update flow: originating Crossdock task id, provider, exact agent task URL, timestamp, and optional initial working branch.

Tests cover successful resolution, required storage/PR validation, and conflicting remote identity failure.

This still does not persist bindings during initial handoff or route the browser continuation flow; it prepares the service read boundary for #153.