### PR TITLE
Expose origin-binding persistence through the service

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -1,5 +1,5 @@
 import { publishExistingInitialHandoff, publishUpdateHandoff } from "./handoff.js";
-import { resolveOriginBinding } from "./origin-binding-storage.js";
+import { persistOriginBinding, resolveOriginBinding } from "./origin-binding-storage.js";
 
 export async function dispatchHandoff({ method, path, body, github }) {
   if (method === "GET" && path === "/health") return { status: 200, body: { ok: true } };
@@ -20,6 +20,38 @@ export async function dispatchHandoff({ method, path, body, github }) {
       pull_request: body.pull_request,
     });
     return { status: 200, body: { repository: task.target_repository, pull_request: task.pull_request, base_branch: task.base_branch, working_branch: task.working_branch, head_sha: task.result_commit } };
+  }
+
+  if (path === "/origin-binding/persist") {
+    requireObject(body, "body");
+    requireObject(body.storage, "storage");
+    const repository = requireRepository(body.target_repository);
+    const pullRequest = requirePullRequest(body.pull_request);
+    const result = await persistOriginBinding({
+      github,
+      storage: body.storage,
+      binding: {
+        target_repository: repository,
+        pull_request: pullRequest,
+        originating_task_id: body.originating_task_id,
+        provider: body.provider,
+        agent_task_url: body.agent_task_url,
+        created_at: body.created_at,
+        ...(body.initial_working_branch == null ? {} : { initial_working_branch: body.initial_working_branch }),
+      },
+    });
+    return {
+      status: 200,
+      body: {
+        repository: result.binding.target_repository,
+        pull_request: result.binding.pull_request,
+        originating_task_id: result.binding.originating_task_id,
+        provider: result.binding.provider,
+        agent_task_url: result.binding.agent_task_url,
+        origin_binding_url: result.url,
+        origin_binding_version: result.version,
+      },
+    };
   }
 
   if (path === "/origin-binding/resolve") {

--- a/tests/origin-binding-persist-service.test.js
+++ b/tests/origin-binding-persist-service.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { dispatchHandoff } from "../src/service.js";
+
+const storage = { repository: "owner/private-records", branch: "main" };
+
+function githubMock() {
+  let stored = null;
+  return {
+    async createFile(repository, path, content, message, branch) {
+      assert.equal(repository, "owner/private-records");
+      assert.equal(path, "crossdock/origins/owner/repo/pull/9.json");
+      assert.match(message, /bind PR #9/);
+      assert.equal(branch, "main");
+      stored = content;
+      return { commit: { sha: "commit-origin" } };
+    },
+    async getFile(repository, path) {
+      assert.equal(repository, "owner/private-records");
+      assert.equal(path, "crossdock/origins/owner/repo/pull/9.json");
+      return { sha: "blob", content: Buffer.from(stored ?? "", "utf8").toString("base64") };
+    },
+    async getLatestCommitForPath() {
+      return { sha: "commit-origin" };
+    },
+  };
+}
+
+test("origin binding persistence endpoint stores immutable routing identity", async () => {
+  const result = await dispatchHandoff({
+    method: "POST",
+    path: "/origin-binding/persist",
+    github: githubMock(),
+    body: {
+      storage,
+      target_repository: " owner/repo ",
+      pull_request: 9,
+      originating_task_id: "crossdock-origin",
+      provider: "codex",
+      agent_task_url: "https://chatgpt.com/codex/cloud/tasks/task_origin",
+      created_at: "2026-09-05T17:00:00Z",
+      initial_working_branch: "codex/example",
+    },
+  });
+
+  assert.equal(result.status, 200);
+  assert.deepEqual(result.body, {
+    repository: "owner/repo",
+    pull_request: 9,
+    originating_task_id: "crossdock-origin",
+    provider: "codex",
+    agent_task_url: "https://chatgpt.com/codex/cloud/tasks/task_origin",
+    origin_binding_url: "https://github.com/owner/private-records/blob/commit-origin/crossdock/origins/owner/repo/pull/9.json",
+    origin_binding_version: "commit-origin",
+  });
+});
+
+test("origin binding persistence endpoint validates provider routing fields", async () => {
+  const base = {
+    storage,
+    target_repository: "owner/repo",
+    pull_request: 9,
+    originating_task_id: "crossdock-origin",
+    provider: "codex",
+    agent_task_url: "https://chatgpt.com/codex/cloud/tasks/task_origin",
+    created_at: "2026-09-05T17:00:00Z",
+  };
+
+  for (const [field, value] of [["originating_task_id", ""], ["provider", ""], ["agent_task_url", "relative"], ["created_at", "bad"]]) {
+    await assert.rejects(
+      dispatchHandoff({ method: "POST", path: "/origin-binding/persist", github: githubMock(), body: { ...base, [field]: value } }),
+    );
+  }
+});


### PR DESCRIPTION
Adds `POST /origin-binding/persist` so the browser/update workflow can persist the immutable PR-to-originating-task binding without coupling that write to PR-visible provenance.

The endpoint requires explicit task-record storage plus exact repository/PR/provider/task identity, delegates to the immutable origin-binding storage helper, verifies the remote record, and returns the durable binding URL/version.

Focused tests cover successful persistence and fail-closed routing-field validation.

This prepares the service write boundary for #153/#163; browser initial-handoff wiring remains separate.