### PR TITLE
Add browser client for durable origin bindings

### DIFF
--- a/extension/origin-binding-client.js
+++ b/extension/origin-binding-client.js
@@ -1,0 +1,104 @@
+import { postServiceJson } from "./service-client.js";
+
+export async function persistOriginBinding({
+  storage,
+  repository,
+  pullRequest,
+  originatingTaskId,
+  provider,
+  agentTaskUrl,
+  createdAt,
+  initialWorkingBranch = null,
+  taskState = null,
+  serviceUrl = null,
+  fetchImpl = globalThis.fetch,
+}) {
+  const body = {
+    storage,
+    target_repository: requireRepository(repository),
+    pull_request: requirePullRequest(pullRequest),
+    originating_task_id: requireString(originatingTaskId, "originating task id"),
+    provider: requireString(provider, "provider"),
+    agent_task_url: requireAbsoluteUrl(agentTaskUrl, "agent task URL"),
+    created_at: requireString(createdAt, "created timestamp"),
+    ...(initialWorkingBranch == null ? {} : { initial_working_branch: requireString(initialWorkingBranch, "initial working branch") }),
+  };
+
+  const result = await postServiceJson({
+    path: "/origin-binding/persist",
+    body,
+    taskState,
+    preference: serviceUrl,
+    fetchImpl,
+  });
+
+  assertResolvedIdentity(result, body.target_repository, body.pull_request);
+  if (result.originating_task_id !== body.originating_task_id) throw new Error("persisted origin binding returned a different originating task id");
+  if (result.provider !== body.provider) throw new Error("persisted origin binding returned a different provider");
+  if (result.agent_task_url !== body.agent_task_url) throw new Error("persisted origin binding returned a different agent task URL");
+  if (typeof result.origin_binding_url !== "string" || !result.origin_binding_url) throw new Error("persisted origin binding returned no durable URL");
+  if (typeof result.origin_binding_version !== "string" || !result.origin_binding_version) throw new Error("persisted origin binding returned no immutable version");
+  return Object.freeze({ ...result });
+}
+
+export async function resolveOriginBinding({
+  storage,
+  repository,
+  pullRequest,
+  taskState = null,
+  serviceUrl = null,
+  fetchImpl = globalThis.fetch,
+}) {
+  const targetRepository = requireRepository(repository);
+  const pr = requirePullRequest(pullRequest);
+  const result = await postServiceJson({
+    path: "/origin-binding/resolve",
+    body: { storage, target_repository: targetRepository, pull_request: pr },
+    taskState,
+    preference: serviceUrl,
+    fetchImpl,
+  });
+
+  assertResolvedIdentity(result, targetRepository, pr);
+  requireString(result.originating_task_id, "resolved originating task id");
+  requireString(result.provider, "resolved provider");
+  requireAbsoluteUrl(result.agent_task_url, "resolved agent task URL");
+  requireString(result.created_at, "resolved created timestamp");
+  if (result.initial_working_branch != null) requireString(result.initial_working_branch, "resolved initial working branch");
+  return Object.freeze({ ...result });
+}
+
+function assertResolvedIdentity(result, repository, pullRequest) {
+  if (!result || typeof result !== "object") throw new Error("origin binding service returned no result");
+  if (result.repository !== repository || result.pull_request !== pullRequest) {
+    throw new Error("origin binding service returned a different repository or PR identity");
+  }
+}
+
+function requireRepository(value) {
+  if (typeof value !== "string" || !/^[^/\s]+\/[^/\s]+$/.test(value.trim())) throw new Error("repository must be owner/repo");
+  return value.trim();
+}
+
+function requirePullRequest(value) {
+  if (!Number.isInteger(value) || value <= 0) throw new Error("pull request must be a positive integer");
+  return value;
+}
+
+function requireString(value, label) {
+  if (typeof value !== "string" || !value.trim()) throw new Error(`${label} is required`);
+  return value.trim();
+}
+
+function requireAbsoluteUrl(value, label) {
+  const text = requireString(value, label);
+  let url;
+  try {
+    url = new URL(text);
+  } catch {
+    throw new Error(`${label} must be an absolute URL`);
+  }
+  if (!/^https?:$/.test(url.protocol)) throw new Error(`${label} must use http or https`);
+  url.hash = "";
+  return url.toString();
+}

--- a/tests/origin-binding-client.test.js
+++ b/tests/origin-binding-client.test.js
@@ -1,0 +1,123 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { persistOriginBinding, resolveOriginBinding } from "../extension/origin-binding-client.js";
+
+const storage = { repository: "owner/private-records", branch: "main" };
+const serviceUrl = "http://127.0.0.1:3210";
+
+function response(body, ok = true, status = 200) {
+  return { ok, status, async json() { return body; } };
+}
+
+test("browser client persists exact origin identity through loopback service", async () => {
+  let request;
+  const fetchImpl = async (url, options) => {
+    request = { url, options, body: JSON.parse(options.body) };
+    return response({
+      repository: "owner/repo",
+      pull_request: 9,
+      originating_task_id: "crossdock-origin",
+      provider: "codex",
+      agent_task_url: "https://chatgpt.com/codex/cloud/tasks/task_origin",
+      origin_binding_url: "https://github.com/owner/private-records/blob/abc/crossdock/origins/owner/repo/pull/9.json",
+      origin_binding_version: "abc",
+    });
+  };
+
+  const result = await persistOriginBinding({
+    storage,
+    repository: "owner/repo",
+    pullRequest: 9,
+    originatingTaskId: "crossdock-origin",
+    provider: "codex",
+    agentTaskUrl: "https://chatgpt.com/codex/cloud/tasks/task_origin",
+    createdAt: "2026-09-05T17:00:00Z",
+    initialWorkingBranch: "codex/example",
+    serviceUrl,
+    fetchImpl,
+  });
+
+  assert.equal(request.url, "http://127.0.0.1:3210/origin-binding/persist");
+  assert.equal(request.options.method, "POST");
+  assert.deepEqual(request.body, {
+    storage,
+    target_repository: "owner/repo",
+    pull_request: 9,
+    originating_task_id: "crossdock-origin",
+    provider: "codex",
+    agent_task_url: "https://chatgpt.com/codex/cloud/tasks/task_origin",
+    created_at: "2026-09-05T17:00:00Z",
+    initial_working_branch: "codex/example",
+  });
+  assert.equal(result.origin_binding_version, "abc");
+  assert.ok(Object.isFrozen(result));
+});
+
+test("browser client resolves exact originating task identity", async () => {
+  const fetchImpl = async (_url, options) => {
+    assert.deepEqual(JSON.parse(options.body), {
+      storage,
+      target_repository: "owner/repo",
+      pull_request: 9,
+    });
+    return response({
+      repository: "owner/repo",
+      pull_request: 9,
+      originating_task_id: "crossdock-origin",
+      provider: "codex",
+      agent_task_url: "https://chatgpt.com/codex/cloud/tasks/task_origin",
+      created_at: "2026-09-05T17:00:00.000Z",
+      initial_working_branch: "codex/example",
+    });
+  };
+
+  const result = await resolveOriginBinding({
+    storage,
+    repository: "owner/repo",
+    pullRequest: 9,
+    serviceUrl,
+    fetchImpl,
+  });
+
+  assert.equal(result.agent_task_url, "https://chatgpt.com/codex/cloud/tasks/task_origin");
+  assert.equal(result.originating_task_id, "crossdock-origin");
+  assert.ok(Object.isFrozen(result));
+});
+
+test("browser client rejects service identity mismatches", async () => {
+  const fetchImpl = async () => response({
+    repository: "owner/other",
+    pull_request: 9,
+    originating_task_id: "crossdock-origin",
+    provider: "codex",
+    agent_task_url: "https://chatgpt.com/codex/cloud/tasks/task_origin",
+    created_at: "2026-09-05T17:00:00.000Z",
+    initial_working_branch: null,
+  });
+
+  await assert.rejects(
+    resolveOriginBinding({ storage, repository: "owner/repo", pullRequest: 9, serviceUrl, fetchImpl }),
+    /different repository or PR identity/,
+  );
+});
+
+test("browser client fails before network mutation on malformed routing input", async () => {
+  let called = false;
+  const fetchImpl = async () => { called = true; return response({}); };
+
+  await assert.rejects(
+    persistOriginBinding({
+      storage,
+      repository: "repo",
+      pullRequest: 9,
+      originatingTaskId: "task",
+      provider: "codex",
+      agentTaskUrl: "https://chatgpt.com/codex/cloud/tasks/task_origin",
+      createdAt: "2026-09-05T17:00:00Z",
+      serviceUrl,
+      fetchImpl,
+    }),
+    /repository must be owner\/repo/,
+  );
+  assert.equal(called, false);
+});


### PR DESCRIPTION
Adds a browser-side client for the origin-binding service endpoints from #163.

The client:
- validates exact repository/PR/provider/task routing identity before network calls;
- persists origin bindings through `/origin-binding/persist`;
- resolves bindings through `/origin-binding/resolve`;
- validates that service responses preserve the requested identity;
- returns frozen result objects;
- keeps the Crossdock service constrained to the existing loopback service client.

Focused tests cover persistence, resolution, response identity mismatch, and pre-network fail-closed validation.

This is preparation for wiring the dashboard update flow in #153.