### PR TITLE
Add Codex continuation identity and readiness core

### DIFF
--- a/extension/codex-continuation.js
+++ b/extension/codex-continuation.js
@@ -1,0 +1,37 @@
+export function canonicalCodexTaskUrl(value) {
+  if (typeof value !== "string" || !value.trim()) throw new Error("Codex task URL is required");
+  let url;
+  try {
+    url = new URL(value.trim());
+  } catch {
+    throw new Error("Codex task URL must be absolute");
+  }
+  if (url.origin !== "https://chatgpt.com") throw new Error("Codex task URL must use https://chatgpt.com");
+  if (!/^\/codex\/cloud\/tasks\/[^/?#]+$/.test(url.pathname)) throw new Error("Codex task URL must identify one concrete cloud task");
+  return `${url.origin}${url.pathname}`;
+}
+
+export function normalizeCodexOriginBinding(binding) {
+  if (!binding || typeof binding !== "object") throw new Error("origin binding is required");
+  if (binding.provider !== "codex") throw new Error(`origin binding provider is not supported by Codex adapter: ${binding.provider ?? "none"}`);
+  if (typeof binding.originating_task_id !== "string" || !binding.originating_task_id.trim()) throw new Error("originating task id is required");
+  return Object.freeze({
+    originating_task_id: binding.originating_task_id.trim(),
+    task_url: canonicalCodexTaskUrl(binding.agent_task_url),
+  });
+}
+
+export function assertCodexContinuationTaskIdentity({ expectedTaskUrl, currentTaskUrl }) {
+  const expected = canonicalCodexTaskUrl(expectedTaskUrl);
+  const current = canonicalCodexTaskUrl(currentTaskUrl);
+  if (current !== expected) throw new Error(`Codex continuation task identity mismatch: expected ${expected}, got ${current}`);
+  return expected;
+}
+
+export function classifyCodexUpdateReadiness({ updateBranchAvailable, createPrAvailable }) {
+  const update = Boolean(updateBranchAvailable);
+  const create = Boolean(createPrAvailable);
+  if (update && create) throw new Error("Codex update readiness is ambiguous: both Update branch and Create PR are available");
+  if (create) throw new Error("Codex normal existing-PR update exposed Create PR instead of Update branch");
+  return Object.freeze({ ready: update, publication_action: update ? "update_branch" : null });
+}

--- a/tests/codex-continuation.test.js
+++ b/tests/codex-continuation.test.js
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  assertCodexContinuationTaskIdentity,
+  canonicalCodexTaskUrl,
+  classifyCodexUpdateReadiness,
+  normalizeCodexOriginBinding,
+} from "../extension/codex-continuation.js";
+
+test("Codex task URL canonicalization requires one concrete cloud task", () => {
+  assert.equal(
+    canonicalCodexTaskUrl("https://chatgpt.com/codex/cloud/tasks/task_abc#report"),
+    "https://chatgpt.com/codex/cloud/tasks/task_abc",
+  );
+  for (const value of [
+    "https://chatgpt.com/codex/cloud",
+    "https://chatgpt.com/codex/cloud/tasks/",
+    "https://example.com/codex/cloud/tasks/task_abc",
+    "/codex/cloud/tasks/task_abc",
+    "",
+  ]) {
+    assert.throws(() => canonicalCodexTaskUrl(value));
+  }
+});
+
+test("Codex origin binding requires codex provider and exact task URL", () => {
+  assert.deepEqual(normalizeCodexOriginBinding({
+    provider: "codex",
+    originating_task_id: "crossdock-origin",
+    agent_task_url: "https://chatgpt.com/codex/cloud/tasks/task_abc",
+  }), {
+    originating_task_id: "crossdock-origin",
+    task_url: "https://chatgpt.com/codex/cloud/tasks/task_abc",
+  });
+  assert.throws(() => normalizeCodexOriginBinding({
+    provider: "other",
+    originating_task_id: "crossdock-origin",
+    agent_task_url: "https://chatgpt.com/codex/cloud/tasks/task_abc",
+  }), /not supported/);
+});
+
+test("continuation task identity must remain exactly the originating task", () => {
+  assert.equal(assertCodexContinuationTaskIdentity({
+    expectedTaskUrl: "https://chatgpt.com/codex/cloud/tasks/task_abc",
+    currentTaskUrl: "https://chatgpt.com/codex/cloud/tasks/task_abc#ignored",
+  }), "https://chatgpt.com/codex/cloud/tasks/task_abc");
+
+  assert.throws(() => assertCodexContinuationTaskIdentity({
+    expectedTaskUrl: "https://chatgpt.com/codex/cloud/tasks/task_abc",
+    currentTaskUrl: "https://chatgpt.com/codex/cloud/tasks/task_other",
+  }), /identity mismatch/);
+});
+
+test("normal existing-PR readiness accepts only Update branch", () => {
+  assert.deepEqual(classifyCodexUpdateReadiness({ updateBranchAvailable: false, createPrAvailable: false }), {
+    ready: false,
+    publication_action: null,
+  });
+  assert.deepEqual(classifyCodexUpdateReadiness({ updateBranchAvailable: true, createPrAvailable: false }), {
+    ready: true,
+    publication_action: "update_branch",
+  });
+  assert.throws(() => classifyCodexUpdateReadiness({ updateBranchAvailable: false, createPrAvailable: true }), /Create PR instead of Update branch/);
+  assert.throws(() => classifyCodexUpdateReadiness({ updateBranchAvailable: true, createPrAvailable: true }), /ambiguous/);
+});


### PR DESCRIPTION
Adds pure browser-adapter helpers for the normal existing-PR continuation path validated in #153.

Includes:
- canonical exact Codex task URL validation;
- normalization of durable origin bindings for the Codex adapter;
- exact continuation task identity checks;
- readiness classification that accepts only `Update branch` for normal existing-PR updates and rejects `Create PR`/ambiguous controls;
- focused tests.

This is wiring preparation only; dashboard/content/background integration remains next.